### PR TITLE
Add React-Helmet to manage changes in the document head

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-helmet": "^6.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,9 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="collections and catalog of the Rockefeller Archive Center"
+      content="Collections and catalog of the Rockefeller Archive Center"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +23,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>DIMES</title>
+    <title>DIMES: Online Collections and Catalog of Rockefeller Archive Center</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/PageAgent.js
+++ b/src/components/PageAgent.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import axios from "axios";
+import {Helmet} from "react-helmet";
 import PageNotFound from "./PageNotFound";
 import TileList from "./Tile";
 import AgentAttributeList from "./AgentAttribute";
@@ -102,17 +103,22 @@ class PageAgent extends Component {
       return (<PageNotFound />)
     }
     return (
-      <div className="container agent">
-        <nav>
-          <a href="/search" className="btn btn--back">Back to Search</a>
-        </nav>
-        <main id="main" role="main">
-          <h1 className="agent__title">{ this.state.agent.title }</h1>
-          <p className="agent__subtitle">{ this.state.agent.description }</p>
-          <AgentDescription attributes={this.state.attributes} />
-          <AgentRelatedCollections collections={this.state.collections} />
-        </main>
-        <AgentSidebar related={this.state.agent.agents} />
+      <div>
+        <Helmet>
+          <title>{ this.state.agent.title }</title>
+        </Helmet>
+        <div className="container agent">
+          <nav>
+            <a href="/search" className="btn btn--back">Back to Search</a>
+          </nav>
+          <main id="main" role="main">
+            <h1 className="agent__title">{ this.state.agent.title }</h1>
+            <p className="agent__subtitle">{ this.state.agent.description }</p>
+            <AgentDescription attributes={this.state.attributes} />
+            <AgentRelatedCollections collections={this.state.collections} />
+          </main>
+          <AgentSidebar related={this.state.agent.agents} />
+        </div>
       </div>
     )
   }

--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Button from "../Button";
 import Dropdown from "../Dropdown";
+import {Helmet} from "react-helmet";
 import SavedItemList from "../SavedItem";
 import "./styles.scss";
 
@@ -91,56 +92,61 @@ class PageMyList extends Component {
   render() {
     // TODO: add onClick handlers for actions
     return (
-      <div className="container mylist flex">
-        <main id="main" role="main">
-          <div className="mylist__header">
-            <h1 className="mylist__title">My List</h1>
-            <Dropdown
-              label="Actions"
-              iconBefore="settings"
-              className="mylist__actions"
-              buttonClassName="btn--orange btn--md"
-              itemClassName="dropdown__item--orange"
-              listClassName="dropdown__list--orange"
-              items={
-                [
-                  {
-                    "label": "Schedule a Visit",
-                    "iconBefore": "account_balance",
-                    "onClick": null
-                  },
-                  {
-                    "label": "Request in Reading Room",
-                    "iconBefore": "local_library",
-                    "onClick": null
-                  },
-                  {
-                    "label": "Request Copies",
-                    "iconBefore": "content_copy",
-                    "onClick": null
-                  },
-                  {
-                    "label": "Email List",
-                    "iconBefore": "email",
-                    "onClick": null
-                  },
-                  {
-                    "label": "Download as .csv",
-                    "iconBefore": "get_app",
-                    "onClick": null
-                  },
-                  {
-                    "label": "Remove All Items",
-                    "iconBefore": "delete",
-                    "onClick": null
-                  }
-                ]
-              } />
-          </div>
-          <MyListExportActions />
-          <SavedItemList items={this.items}/>
-        </main>
-        <MyListSidebar/>
+      <div>
+        <Helmet>
+          <title>DIMES: My List</title>
+        </Helmet>
+        <div className="container mylist flex">
+          <main id="main" role="main">
+            <div className="mylist__header">
+              <h1 className="mylist__title">My List</h1>
+              <Dropdown
+                label="Actions"
+                iconBefore="settings"
+                className="mylist__actions"
+                buttonClassName="btn--orange btn--md"
+                itemClassName="dropdown__item--orange"
+                listClassName="dropdown__list--orange"
+                items={
+                  [
+                    {
+                      "label": "Schedule a Visit",
+                      "iconBefore": "account_balance",
+                      "onClick": null
+                    },
+                    {
+                      "label": "Request in Reading Room",
+                      "iconBefore": "local_library",
+                      "onClick": null
+                    },
+                    {
+                      "label": "Request Copies",
+                      "iconBefore": "content_copy",
+                      "onClick": null
+                    },
+                    {
+                      "label": "Email List",
+                      "iconBefore": "email",
+                      "onClick": null
+                    },
+                    {
+                      "label": "Download as .csv",
+                      "iconBefore": "get_app",
+                      "onClick": null
+                    },
+                    {
+                      "label": "Remove All Items",
+                      "iconBefore": "delete",
+                      "onClick": null
+                    }
+                  ]
+                } />
+            </div>
+            <MyListExportActions />
+            <SavedItemList items={this.items}/>
+          </main>
+          <MyListSidebar/>
+        </div>
       </div>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8997,6 +8997,21 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -9090,6 +9105,11 @@ react-scripts@3.4.1:
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.1.2"
+
+react-side-effect@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.0.tgz#1ce4a8b4445168c487ed24dab886421f74d380d3"
+  integrity sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==
 
 react@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
Implements [React-Helmet](https://github.com/nfl/react-helmet) to manage changes to the document head, including `title` and other meta tags. Fixes #3 .

- Adds page titles for My List and Agent pages
- Updates `public/index.html` default page title

React-Helmet works for users, Google, and some services, but not all crawlers can access the dynamic tags for client-side rendered apps, and just take the initial bundle. There are ways to [dynamically set the meta tags server side](https://www.kapwing.com/blog/how-to-add-dynamic-meta-tags-server-side-with-create-react-app/), which we can address as a separate issue.