### PR TITLE
Improve responsiveness of top nav

### DIFF
--- a/src/components/Dropdown/__tests__/Dropdown.test.js
+++ b/src/components/Dropdown/__tests__/Dropdown.test.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { render } from "react-dom";
+import {MyListDropdown, NavDropdown} from "../../Dropdown";
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(<MyListDropdown />, div);
+});
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(<NavDropdown />, div);
+});

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,10 +1,10 @@
-import React, { Component, useState } from 'react';
+import React, { useState } from 'react';
 import useDropdownMenu from 'react-accessible-dropdown-menu-hook';
 import MaterialIcon from "../MaterialIcon";
 import "../Button/styles.scss";
 import "./styles.scss";
 
-const Dropdown = props => {
+const Dropdown = (props) => {
   const [buttonClassName] = useState(props.buttonClassName);
   const [className] = useState(props.className);
   const [iconBefore] = useState(props.iconBefore);
@@ -20,7 +20,7 @@ const Dropdown = props => {
       key={idx}
       id={`menu-item-${idx}`}
       className={`btn ${itemClassName}`}
-      onClick={item.onClick}
+      onClick={item.handleClick}
       href={item.href}
       {...itemProps[idx]}>{item.iconBefore && <MaterialIcon icon={item.iconBefore} />}{item.label}{item.iconAfter && <MaterialIcon icon={item.iconAfter} />}</a>
   );
@@ -41,78 +41,70 @@ const Dropdown = props => {
   )
 }
 
-export class MyListDropdown extends Component {
-  render() {
-    return (
-      <Dropdown
-        label="Actions"
-        iconBefore="settings"
-        className="mylist__actions"
-        buttonClassName="btn btn--orange btn--md"
-        itemClassName="btn--orange btn--dropdown dropdown__item--orange"
-        listClassName="dropdown__list--orange"
-        items={
-          [
-            {
-              "label": "Schedule a Visit",
-              "iconBefore": "account_balance",
-              "onClick": null
-            },
-            {
-              "label": "Request in Reading Room",
-              "iconBefore": "local_library",
-              "onClick": null
-            },
-            {
-              "label": "Request Copies",
-              "iconBefore": "content_copy",
-              "onClick": null
-            },
-            {
-              "label": "Email List",
-              "iconBefore": "email",
-              "onClick": null
-            },
-            {
-              "label": "Download as .csv",
-              "iconBefore": "get_app",
-              "onClick": null
-            },
-            {
-              "label": "Remove All Items",
-              "iconBefore": "delete",
-              "onClick": this.props.removeAllItems
-            }
-          ]
-        } />
-    )
-  }
-}
+export const MyListDropdown = ({ removeAllItems }) => (
+  <Dropdown
+    label="Actions"
+    iconBefore="settings"
+    className="mylist__actions"
+    buttonClassName="btn btn--orange btn--md"
+    itemClassName="btn--orange btn--dropdown dropdown__item--orange"
+    listClassName="dropdown__list--orange"
+    items={
+      [
+        {
+          "label": "Schedule a Visit",
+          "iconBefore": "account_balance",
+          "handleClick": null
+        },
+        {
+          "label": "Request in Reading Room",
+          "iconBefore": "local_library",
+          "handleClick": null
+        },
+        {
+          "label": "Request Copies",
+          "iconBefore": "content_copy",
+          "handleClick": null
+        },
+        {
+          "label": "Email List",
+          "iconBefore": "email",
+          "handleClick": null
+        },
+        {
+          "label": "Download as .csv",
+          "iconBefore": "get_app",
+          "handleClick": null
+        },
+        {
+          "label": "Remove All Items",
+          "iconBefore": "delete",
+          "handleClick": removeAllItems
+        }
+      ]
+    } />
+  )
 
-export class NavDropdown extends Component {
-  render() {
-    return (
-      <Dropdown
-        iconBefore="menu"
-        iconBeforeOpen="close"
-        className="nav-mobile hide-on-md-up"
-        buttonClassName="btn nav-mobile__btn"
-        itemClassName="btn--navy btn--mobile-dropdown dropdown__item--navy"
-        listClassName="dropdown__list--mobile dropdown__list--navy"
-        items={
-          [
-            {
-              "label": "Sign in to RACcess",
-              "iconAfter": "east",
-              "onClick": null
-            },
-            {
-              "label": "My List",
-              "iconAfter": "east",
-              "onClick": null
-            }
-          ]
-        } />
-    )
-  }
-}
+export const NavDropdown = () => (
+  <Dropdown
+    iconBefore="menu"
+    iconBeforeOpen="close"
+    className="nav-mobile hide-on-md-up"
+    buttonClassName="btn nav-mobile__btn"
+    itemClassName="btn--navy btn--mobile-dropdown dropdown__item--navy"
+    listClassName="dropdown__list--mobile dropdown__list--navy"
+    items={
+      [
+        {
+          "label": "Sign in to RACcess",
+          "iconAfter": "east",
+          "handleClick": null
+        },
+        {
+          "label": "My List",
+          "iconAfter": "east",
+          "handleClick": null
+        }
+      ]
+    } />
+)

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -89,7 +89,7 @@ export const NavDropdown = () => (
   <Dropdown
     iconBefore="menu"
     iconBeforeOpen="close"
-    className="nav-mobile hide-on-md-up"
+    className="nav-mobile hide-on-lg-up"
     buttonClassName="btn nav-mobile__btn"
     itemClassName="btn--navy btn--mobile-dropdown dropdown__item--navy"
     listClassName="dropdown__list--mobile dropdown__list--navy"

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,28 +1,39 @@
-import React, { useState } from 'react';
+import React, { Component, useState } from 'react';
 import useDropdownMenu from 'react-accessible-dropdown-menu-hook';
 import MaterialIcon from "../MaterialIcon";
 import "../Button/styles.scss";
 import "./styles.scss";
 
 const Dropdown = props => {
-  const [opts] = useState(props);
-  const { buttonProps, itemProps, isOpen } = useDropdownMenu(opts.items.length);
-  const listItems = opts.items.map((item, idx) =>
-        <a
-          key={idx}
-          id={`menu-item-${idx}`}
-          className={`btn btn--orange btn--dropdown ${opts.itemClassName}`}
-          onClick={item.onClick}
-          href={item.href}
-          {...itemProps[idx]}>{item.iconBefore && <MaterialIcon icon={item.iconBefore} />}{item.label}</a>
-      );
+  const [buttonClassName] = useState(props.buttonClassName);
+  const [className] = useState(props.className);
+  const [iconBefore] = useState(props.iconBefore);
+  const [iconBeforeOpen] = useState(props.iconBeforeOpen);
+  const [items] = useState(props.items);
+  const [itemClassName] = useState(props.itemClassName);
+  const [label] = useState(props.label);
+  const [listClassName] = useState(props.listClassName);
+  const { buttonProps, itemProps, isOpen } = useDropdownMenu(items.length);
+  const openIcon = iconBeforeOpen ? iconBeforeOpen : iconBefore
+  const listItems = items.map((item, idx) =>
+    <a
+      key={idx}
+      id={`menu-item-${idx}`}
+      className={`btn ${itemClassName}`}
+      onClick={item.onClick}
+      href={item.href}
+      {...itemProps[idx]}>{item.iconBefore && <MaterialIcon icon={item.iconBefore} />}{item.label}{item.iconAfter && <MaterialIcon icon={item.iconAfter} />}</a>
+  );
   return (
-    <div className={`dropdown ${opts.className}`}>
+    <div className={`dropdown ${className}`}>
       <button
-        className={`dropdown__button ${opts.buttonClassName}`}
-        {...buttonProps} >{opts.iconBefore && <MaterialIcon icon={opts.iconBefore} />}{opts.label}</button>
+        className={`dropdown__button ${buttonClassName} ${isOpen ? "open" : "closed" }`}
+        {...buttonProps} >
+          {isOpen ? (<MaterialIcon icon={openIcon} />) : (iconBefore && <MaterialIcon icon={iconBefore} />)}
+          {label}
+      </button>
       <div
-        className={`dropdown__list ${opts.listClassName} ${isOpen ? "open" : "closed" }`}
+        className={`dropdown__list ${listClassName} ${isOpen ? "open" : "closed" }`}
         role="menu" >
         {listItems}
       </div>
@@ -30,4 +41,78 @@ const Dropdown = props => {
   )
 }
 
-export default Dropdown;
+export class MyListDropdown extends Component {
+  render() {
+    return (
+      <Dropdown
+        label="Actions"
+        iconBefore="settings"
+        className="mylist__actions"
+        buttonClassName="btn btn--orange btn--md"
+        itemClassName="btn--orange btn--dropdown dropdown__item--orange"
+        listClassName="dropdown__list--orange"
+        items={
+          [
+            {
+              "label": "Schedule a Visit",
+              "iconBefore": "account_balance",
+              "onClick": null
+            },
+            {
+              "label": "Request in Reading Room",
+              "iconBefore": "local_library",
+              "onClick": null
+            },
+            {
+              "label": "Request Copies",
+              "iconBefore": "content_copy",
+              "onClick": null
+            },
+            {
+              "label": "Email List",
+              "iconBefore": "email",
+              "onClick": null
+            },
+            {
+              "label": "Download as .csv",
+              "iconBefore": "get_app",
+              "onClick": null
+            },
+            {
+              "label": "Remove All Items",
+              "iconBefore": "delete",
+              "onClick": this.props.removeAllItems
+            }
+          ]
+        } />
+    )
+  }
+}
+
+export class NavDropdown extends Component {
+  render() {
+    return (
+      <Dropdown
+        iconBefore="menu"
+        iconBeforeOpen="close"
+        className="nav-mobile hide-on-md-up"
+        buttonClassName="btn nav-mobile__btn"
+        itemClassName="btn--navy btn--mobile-dropdown dropdown__item--navy"
+        listClassName="dropdown__list--mobile dropdown__list--navy"
+        items={
+          [
+            {
+              "label": "Sign in to RACcess",
+              "iconAfter": "east",
+              "onClick": null
+            },
+            {
+              "label": "My List",
+              "iconAfter": "east",
+              "onClick": null
+            }
+          ]
+        } />
+    )
+  }
+}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -7,14 +7,14 @@ class Header extends Component {
     return (
       <header className="header-secondary">
         <div className="wrapper">
-          <div className="container">
+          <div className="container--full-width">
             <div className="header-secondary__brand">
               <a href="/" className="header-secondary__title">dimes.rockarch.org</a>
               <p className="header-secondary__subtitle">The Online Collection and Catalog of Rockefeller Archive Center</p>
             </div>
             <Nav ariaLabel="Main">
-              <NavItem href="#" label="Sign in to RACcess" icon="arrow_right_alt" />
-              <NavItem href="list" label={`My List${this.props.myListCount > 0  ? ` (${this.props.myListCount})` : ""}`} icon="arrow_right_alt" />
+              <NavItem href="#" label="Sign in to RACcess" icon="east" />
+              <NavItem href="list" label={`My List${this.props.myListCount > 0  ? ` (${this.props.myListCount})` : ""}`} icon="east" />
             </Nav>
           </div>
         </div>

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -1,13 +1,16 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import MaterialIcon from "../MaterialIcon";
+import {NavDropdown} from "../Dropdown";
 import "./styles.scss";
 
 export class NavItem extends Component {
   render() {
     return (
-      <li className={`nav__item ${this.props.className}`}>
-        <a className={`nav__link ${this.props.className}`} href={this.props.href}>{this.props.label} {this.props.icon && <MaterialIcon icon={this.props.icon} />}</a>
+      <li className={`nav__item ${this.props.className ? this.props.className : ""}`}>
+        <a
+          className={`nav__link ${this.props.className ? this.props.className : ""}`}
+          href={this.props.href}>{this.props.label} {this.props.icon && <MaterialIcon icon={this.props.icon} />}</a>
       </li>
     )
   }
@@ -23,10 +26,11 @@ NavItem.propTypes = {
 export class Nav extends Component {
   render() {
     return (
-      <nav className={`nav ${this.props.className && this.props.className}`} aria-label={this.props.ariaLabel}>
-        <ul className="nav__list">
+      <nav className={`nav ${this.props.className ? this.props.className : ""}`} aria-label={this.props.ariaLabel}>
+        <ul className="nav__list show-on-md-up">
           {this.props.children}
         </ul>
+        <NavDropdown />
       </nav>
     )
   }

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -18,7 +18,7 @@ NavItem.propTypes = {
 }
 
 export const Nav = ({ ariaLabel, children, className}) => (
-  <nav className={`nav ${className && className} : ""`} aria-label={ariaLabel}>
+  <nav className={`nav ${className ? className : ""}`} aria-label={ariaLabel}>
     <ul className="nav__list show-on-md-up">
       {children}
     </ul>

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -19,7 +19,7 @@ NavItem.propTypes = {
 
 export const Nav = ({ ariaLabel, children, className}) => (
   <nav className={`nav ${className ? className : ""}`} aria-label={ariaLabel}>
-    <ul className="nav__list show-on-md-up">
+    <ul className="nav__list show-on-lg-up">
       {children}
     </ul>
     <NavDropdown />

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -18,10 +18,11 @@ NavItem.propTypes = {
 }
 
 export const Nav = ({ ariaLabel, children, className}) => (
-  <nav className={`nav ${className && className}`} aria-label={ariaLabel}>
-    <ul className="nav__list">
+  <nav className={`nav ${className && className} : ""`} aria-label={ariaLabel}>
+    <ul className="nav__list show-on-md-up">
       {children}
     </ul>
+    <NavDropdown />
   </nav>)
 
 Nav.propTypes = {

--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -149,47 +149,6 @@ class PageMyList extends Component {
             <div className="mylist__header">
               <h1 className="mylist__title">My List</h1>
               <MyListDropdown removeAllItems={this.removeAllItems} />
-              <Dropdown
-                label="Actions"
-                iconBefore="settings"
-                className="mylist__actions"
-                buttonClassName="btn btn--orange btn--md"
-                itemClassName="dropdown__item--orange"
-                listClassName="dropdown__list--orange"
-                items={
-                  [
-                    {
-                      "label": "Schedule a Visit",
-                      "iconBefore": "account_balance",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Request in Reading Room",
-                      "iconBefore": "local_library",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Request Copies",
-                      "iconBefore": "content_copy",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Email List",
-                      "iconBefore": "email",
-                      "onClick": () => this.toggleModal("email")
-                    },
-                    {
-                      "label": "Download as .csv",
-                      "iconBefore": "get_app",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Remove All Items",
-                      "iconBefore": "delete",
-                      "onClick": this.removeAllItems
-                    }
-                  ]
-                } />
             </div>
             <MyListExportActions
               removeAllItems={this.removeAllItems}

--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -9,7 +9,7 @@ import {SavedItemList} from "../SavedItem";
 import "./styles.scss";
 
 const MyListExportActions = ({emailList, removeAllItems}) => (
-  <div className="mylist__export-actions">
+  <div className="mylist__export-actions show-on-lg-up">
     <Button
       className="btn--orange btn--sm"
       label="Email List"
@@ -33,7 +33,7 @@ MyListExportActions.propTypes = {
 
 const MyListSidebar = () => (
 // TODO: add onClick actions
-  <aside className="mylist__sidebar">
+  <aside className="mylist__sidebar show-on-lg-up">
     <Button
       className="btn--orange btn--lg"
       label="Schedule a Visit"

--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from "prop-types";
 import axios from "axios";
 import Button from "../Button";
-import Dropdown from "../Dropdown";
+import {MyListDropdown} from "../Dropdown";
 import {Helmet} from "react-helmet";
 import SavedItemList from "../SavedItem";
 import "./styles.scss";
@@ -147,47 +147,7 @@ class PageMyList extends Component {
           <main id="main" role="main">
             <div className="mylist__header">
               <h1 className="mylist__title">My List</h1>
-              <Dropdown
-                label="Actions"
-                iconBefore="settings"
-                className="mylist__actions"
-                buttonClassName="btn btn--orange btn--md"
-                itemClassName="dropdown__item--orange"
-                listClassName="dropdown__list--orange"
-                items={
-                  [
-                    {
-                      "label": "Schedule a Visit",
-                      "iconBefore": "account_balance",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Request in Reading Room",
-                      "iconBefore": "local_library",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Request Copies",
-                      "iconBefore": "content_copy",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Email List",
-                      "iconBefore": "email",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Download as .csv",
-                      "iconBefore": "get_app",
-                      "onClick": null
-                    },
-                    {
-                      "label": "Remove All Items",
-                      "iconBefore": "delete",
-                      "onClick": this.removeAllItems
-                    }
-                  ]
-                } />
+              <MyListDropdown removeAllItems={this.removeAllItems} />
             </div>
             <MyListExportActions removeAllItems={this.removeAllItems} />
             <SavedItemList

--- a/src/styles/base/_grid.scss
+++ b/src/styles/base/_grid.scss
@@ -9,6 +9,12 @@ $grid-column: (
   box-sizing: border-box
 ); //does this work??
 
+.container--full-width {
+  width: 100%;
+  max-width: 1440px;
+  @include grid-container;
+}
+
 .container {
   width: calc(100% - (#{$gutters-default}) * 2);
   max-width: 1440px;

--- a/src/styles/base/_utilities.scss
+++ b/src/styles/base/_utilities.scss
@@ -1,3 +1,5 @@
+@import "../variables/vars";
+
 $transition-default: all 0.2s ease;
 
 @mixin visually-hidden {
@@ -23,4 +25,18 @@ $transition-default: all 0.2s ease;
 
 .flex {
   display: flex;
+}
+
+.show-on-md-up {
+  display: none;
+  @media screen and (min-width: $break-md) {
+    display: block;
+  }
+}
+
+.hide-on-md-up {
+  display: block;
+  @media screen and (min-width: $break-md) {
+    display: none
+  }
 }

--- a/src/styles/base/_utilities.scss
+++ b/src/styles/base/_utilities.scss
@@ -41,9 +41,16 @@ $transition-default: all 0.2s ease;
   }
 }
 
-@mixin show-in-lg {
+.show-on-lg-up {
   display: none;
   @media screen and (min-width: $break-lg) {
     display: block;
+  }
+}
+
+.hide-on-lg-up {
+  display: block;
+  @media screen and (min-width: $break-lg) {
+    display: none;
   }
 }

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -65,6 +65,16 @@
   }
 }
 
+.btn--navy {
+  background: $deep-navy;
+  color: $pure-white;
+  border: none;
+  &:hover {
+    background: $dark-blue;
+    color: $off-white;
+  }
+}
+
 .btn--orange {
   background: $burnt-orange;
   color: $pure-white;

--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -14,6 +14,7 @@
   border-radius: 3px;
   padding: 20px 0px;
   width: 270px;
+  transition: $transition-default;
   &.open {
     display: block;
     z-index: 999;
@@ -26,4 +27,47 @@
 .dropdown__list--orange {
   background-color: $burnt-orange;
   color: $pure-white;
+}
+
+.mylist__actions {
+  margin-top: 40px;
+  margin-bottom: 30px;
+  display: block;
+  float: right;
+  @media screen and (min-width: $break-lg) {
+    display: none;
+  }
+}
+
+.nav-mobile__btn {
+  height: 20px;
+  margin: 20px;
+  padding: 0;
+  background-color: $deep-navy;
+  color: $pure-white;
+  border: none;
+  & .material-icons {
+    font-size: 20px;
+    line-height: 20px;
+  }
+}
+
+.dropdown__list--mobile {
+  @extend .dropdown__list;
+  width: 240px;
+  position: fixed;
+  right: 0;
+  top: 50px;
+  height: 100%;
+  margin: 0;
+  border-radius: 0;
+}
+
+.dropdown__list--navy {
+  background: $deep-navy
+}
+
+.btn--mobile-dropdown  {
+  @extend .btn--dropdown;
+  padding: 12px 24px;
 }

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -27,12 +27,11 @@
   box-sizing: border-box;
   @media screen and (min-width: $break-md) {
     margin-top:16px;
-    @include grid-column(6);
   }
   @media screen and (min-width: $break-lg) {
     @include grid-column(7);
     margin-top:21px;
-    margin-left: 80px;
+    padding-left: 80px;
     & .subtitle {
       float: left;
       margin-top: 4px;

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -21,9 +21,10 @@
 
 .header-secondary__brand {
   margin-left: 20px;
-  margin-top:9px;
+  margin-top: 9px;
   z-index: 3;
-  @include grid-column(7);
+  @include grid-column(11);
+  box-sizing: border-box;
   @media screen and (min-width: $break-md) {
     margin-top:16px;
     @include grid-column(6);

--- a/src/styles/components/_my-list.scss
+++ b/src/styles/components/_my-list.scss
@@ -12,12 +12,10 @@
 }
 
 .mylist__export-actions {
-  @include show-in-lg;
   padding-bottom: 30px;
 }
 
 .mylist__sidebar {
-  @include show-in-lg;
   @include grid-column(4);
   background: #F8F8F7;
   float: right;

--- a/src/styles/components/_my-list.scss
+++ b/src/styles/components/_my-list.scss
@@ -37,13 +37,3 @@
 .mylist__title {
   margin-top: 40px;
 }
-
-.mylist__actions {
-  margin-top: 40px;
-  margin-bottom: 30px;
-  display: block;
-  float: right;
-  @media screen and (min-width: $break-lg) {
-    display: none;
-  }
-}

--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -2,20 +2,15 @@
 
 .nav {
   text-align: right;
+  float: right;
   text-transform: uppercase;
   @include grid-column(1);
   margin-left: 0;
-  border-left: 1px solid $med-dark-gray;
   height: 60px;
   box-sizing: border-box;
-  @media screen and (min-width: $break-md) {
-    @include grid-column(6);
-    border: none;
-    float: right;
-    padding-left: 0px;
-  }
   @media screen and (min-width: $break-lg) {
-    @include grid-column(4);
+    @include grid-column(5);
+    border: none;
     float: right;
   }
 }
@@ -25,8 +20,7 @@
   padding: 0;
   box-sizing: border-box;
   @media screen and (min-width: $break-lg) {
-    margin-right: 80px;
-    border-right: 1px solid $med-dark-gray;
+    margin-right: -15px;
   }
 }
 .nav__item {

--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -3,10 +3,16 @@
 .nav {
   text-align: right;
   text-transform: uppercase;
-  @include grid-column(5);
+  @include grid-column(1);
+  margin-left: 0;
+  border-left: 1px solid $med-dark-gray;
+  height: 60px;
+  box-sizing: border-box;
   @media screen and (min-width: $break-md) {
     @include grid-column(6);
+    border: none;
     float: right;
+    padding-left: 0px;
   }
   @media screen and (min-width: $break-lg) {
     @include grid-column(4);
@@ -14,9 +20,18 @@
   }
 }
 
-.nav__list {margin: 0;}
+.nav__list {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  @media screen and (min-width: $break-lg) {
+    margin-right: 80px;
+    border-right: 1px solid $med-dark-gray;
+  }
+}
 .nav__item {
   display: inline-block;
+  border-left: 1px solid $med-dark-gray;
   &:hover {
     background-color: $deep-blue;
     transition: $transition-default


### PR DESCRIPTION
Moves all dropdowns into Dropdown component and adds a NavDropdown for mobile nav.

Note: the design treatments calls for behavior which pushes the main content left when the menu is open. I did not implement this because it seemed like that would require adding `margin-left` and `margin-right` properties on `#root`, and my brain couldn't wrap itself around how to do that.  I'm going to file an issue, but I suspect this will likely require setting state in `App.js` and then passing that down to the menu via props.

fixes #32 