### PR TITLE
Standarizes colors

### DIFF
--- a/src/components/PageHome/index.js
+++ b/src/components/PageHome/index.js
@@ -5,7 +5,7 @@ import "./styles.scss";
 
 const PageHome = () => (
 // TODO: implement page background-color $off-white
-  <div className="container">
+  <div className="container--full-width home">
     <Hero />
     <SearchForm className="search-form--home"/>
   </div>)

--- a/src/components/PageHome/index.js
+++ b/src/components/PageHome/index.js
@@ -4,7 +4,7 @@ import SearchForm from "../SearchForm";
 import "./styles.scss";
 
 const PageHome = () => (
-// TODO: implement page background-color $light-grayish-yellow
+// TODO: implement page background-color $off-white
   <div className="container">
     <Hero />
     <SearchForm className="search-form--home"/>

--- a/src/styles/base/_layout.scss
+++ b/src/styles/base/_layout.scss
@@ -347,7 +347,3 @@ section {
     }
   }
 }
-
-.color-pagehome {
-  background-color: $light-grayish-yellow;
-}

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -229,6 +229,7 @@ small {
   @include tile-text;
   font-size: 11px;
   line-height: 11px;
+  font-weight: 700;
   color: $pure-white;
 }
 

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -51,7 +51,7 @@ h2, h3, h4, h5, h6 {
 
 h2 {
   font-size: 21px;
-  border-bottom: 1.5px dotted $deep-navy;
+  border-bottom: 1.5px dotted $faded-navy;
   padding-bottom: 12px;
   margin-bottom: 20px;
   margin-top: 60px;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -214,7 +214,7 @@ small {
   @include tile-text;
   font-weight: 700;
   font-size: 18px;
-  color: #2F2F2F;
+  color: $dark-gray;
   line-height: 22px;
 }
 
@@ -222,14 +222,14 @@ small {
   @include tile-text;
   font-weight: 400;
   font-size: 15px;
-  color: #2F2F2F;
+  color: $dark-gray;
 }
 
 @mixin tile-hit-count-text  {
   @include tile-text;
   font-size: 11px;
   line-height: 11px;
-  color: #FFFFFF;
+  color: $pure-white;
 }
 
 @mixin tile-type-label-text {

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -237,7 +237,7 @@ small {
   text-transform: uppercase;
   font-weight: 900;
   font-size: 12px;
-  color: #A75C39;
+  color: $red-brown;
   letter-spacing: 0.1em;
 }
 

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -51,7 +51,7 @@ h2, h3, h4, h5, h6 {
 
 h2 {
   font-size: 21px;
-  border-bottom: 1.5px dotted $faded-navy;
+  border-bottom: 1.5px dotted $deep-navy;
   padding-bottom: 12px;
   margin-bottom: 20px;
   margin-top: 60px;

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -105,16 +105,16 @@
 .btn--transparent {
   background: transparent;
   border: 1px solid $light-med-gray;
-  color: $med-dark-gray;
+  color: $med-gray;
 }
 
 .btn--gray {
   background: $off-white;
-  color: $med-dark-gray;
+  color: $med-gray;
   border: 1px solid $light-med-gray;
   &:hover {
     background: $lighter-gray;
-    color: $med-dark-gray;
+    color: $med-gray;
   }
 }
 

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -6,7 +6,7 @@
 }
 
 @mixin placeholder-text {
-  color: $dim-gray;
+  color: $med-gray;
   font-size: 18px;
 }
 

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -135,7 +135,7 @@
   float: left;
   width: 100%;
   height: 100%;
-  background-color: $light-grayish-yellow;
+  background-color: $off-white;
   border-top: 1px solid $neutral-sand;
   padding: 30px 20px;
   box-sizing: border-box;

--- a/src/styles/components/_my-list.scss
+++ b/src/styles/components/_my-list.scss
@@ -17,7 +17,7 @@
 
 .mylist__sidebar {
   @include grid-column(4);
-  background: #F8F8F7;
+  background: $light-grayish-yellow;
   float: right;
   margin-left: 45px;
   margin-right: -45px;

--- a/src/styles/components/_my-list.scss
+++ b/src/styles/components/_my-list.scss
@@ -17,7 +17,7 @@
 
 .mylist__sidebar {
   @include grid-column(4);
-  background: $light-grayish-yellow;
+  background: $off-white;
   float: right;
   margin-left: 45px;
   margin-right: -45px;

--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -25,7 +25,7 @@
 }
 .nav__item {
   display: inline-block;
-  border-left: 1px solid $med-dark-gray;
+  border-left: 1px solid $med-gray;
   &:hover {
     background-color: $deep-blue;
     transition: $transition-default

--- a/src/styles/components/_page-home.scss
+++ b/src/styles/components/_page-home.scss
@@ -1,1 +1,5 @@
 @import "../styles";
+
+.home {
+  background: $off-white;
+}

--- a/src/styles/components/_saved-item.scss
+++ b/src/styles/components/_saved-item.scss
@@ -5,7 +5,7 @@
 .saved-items__empty,
 .modal-saved-items__item-group {
   @include grid-column(12);
-  border-top: 1px dotted $faded-navy;
+  border-top: 1px dotted $deep-navy;
 }
 
 .saved-items__empty {

--- a/src/styles/components/_saved-item.scss
+++ b/src/styles/components/_saved-item.scss
@@ -5,7 +5,7 @@
 .saved-items__empty,
 .modal-saved-items__item-group {
   @include grid-column(12);
-  border-top: 1px dotted $deep-navy;
+  border-top: 1px dotted $faded-navy;
 }
 
 .saved-items__empty {

--- a/src/styles/components/_skip-link.scss
+++ b/src/styles/components/_skip-link.scss
@@ -3,7 +3,7 @@
 .skip-link {
   font-family: $sans-serif-stack;
   background: $burnt-orange;
-  color: $pure-white;
+  color: $off-white;
   padding: 15px 20px 18px 20px;
   position: absolute;
   left: 80px;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -3,6 +3,7 @@
 
 // Colors
 $burnt-orange: #D8531E; //RAC logo, link, button, dropdown, form error, social icons hover
+$red-brown: #A75C39; //tile label text
 $med-brown: #9E3C0F; //button hover, and search button border
 $deep-brown: #662700; //NOT USED
 

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -2,32 +2,36 @@
 
 
 // Colors
-$burnt-orange: #D8531E;
-$med-brown: #9E3C0F;
-$deep-brown: #662700;
+$burnt-orange: #D8531E; //RAC logo, link, button, dropdown, form error, social icons hover
+$med-brown: #9E3C0F; //button hover, and search button border
+$deep-brown: #662700; //NOT USED
 
-$red-orange: #F16943;
-$faded-orange: #F39452;
-$light-orange: #FFE5E5;
+$red-orange: #F16943; //link hover, tile border hover, hit count
+$faded-orange: #F39452; //h4
+$light-orange: #FFE5E5; //modal form error
 
 $deep-navy: #192E49;
 $faded-navy: rgba(25,45,73,0.5);
-$light-blue: #C6D2DE;
-$pale-blue: #EBEFF4;
-$deep-blue: #1A5096;
-$dark-blue: #113768;
+$dark-blue: #113768; //button hover
+$deep-blue: #1A5096; //button background and border, dropdown hover
+$light-blue: #C6D2DE; //facet border and button border
+$pale-blue: #EBEFF4; //background
 
-$lighter-gray: #EDEDEB;
-$light-gray: rgba(0,0,0,0.15);
-$light-grayish-yellow: #F8F8F7; //DIMES Homepage background
-$light-med-gray: #A9A9A9;
-$med-gray: #5B5B5B;
-$med-dark-gray: #525252;
-$dark-gray: #2F2F2F;
-$orange-gray: #BCBAB4;
-$neutral-sand: #E3E1DD;
-$off-white: #F6F6F4;
-$pure-white: #FFFFFF;
+
+$light-gray: rgba(0,0,0,0.15); //box shadow
+$dark-gray: #2F2F2F; //typography and border
+$med-dark-gray: #525252; //button color and nav border
+$med-gray: #5B5B5B; //help and placeholder text
+$light-med-gray: #A9A9A9; //button border
+$orange-gray: #BCBAB4; //tile border
+$neutral-sand: #E3E1DD; //footer background and border
+$lighter-gray: #EDEDEB; //button hover
+$light-grayish-yellow: #F8F8F7; //modal form background and homepage background
+$off-white: #F6F6F4; //footer and button text and tile background
+$pure-white: #FFFFFF; //skip link text, input background, button text, modal background, modal title
+
+
+
 
 // Layout
 $content-width: 1440px;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -11,7 +11,6 @@ $faded-orange: #F39452;
 $light-orange: #FFE5E5;
 
 $deep-navy: #192E49;
-$faded-navy: rgba(25,45,73,0.5);
 $light-blue: #C6D2DE;
 $pale-blue: #EBEFF4;
 $deep-blue: #1A5096;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -11,6 +11,7 @@ $faded-orange: #F39452;
 $light-orange: #FFE5E5;
 
 $deep-navy: #192E49;
+$faded-navy: rgba(25,45,73,0.5);
 $light-blue: #C6D2DE;
 $pale-blue: #EBEFF4;
 $deep-blue: #1A5096;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -1,34 +1,30 @@
-// TODO: align colors between RAC website and DIMES. There are many close matches.
-
 
 // Colors
-$burnt-orange: #D8531E; //RAC logo, link, button, dropdown, form error, social icons hover
+$burnt-orange: #D8531E;
 $red-brown: #A75C39; //tile label text
-$med-brown: #9E3C0F; //button hover, and search button border
+$med-brown: #9E3C0F;
 $deep-brown: #662700; //NOT USED
 
-$red-orange: #F16943; //link hover, tile border hover, hit count
+$red-orange: #F16943;
 $faded-orange: #F39452; //h4
 $light-orange: #FFE5E5; //modal form error
 
 $deep-navy: #192E49;
 $faded-navy: rgba(25,45,73,0.5);
 $dark-blue: #113768; //button hover
-$deep-blue: #1A5096; //button background and border, dropdown hover
-$light-blue: #C6D2DE; //facet border and button border
-$pale-blue: #EBEFF4; //background
+$deep-blue: #1A5096;
+$light-blue: #C6D2DE;
+$pale-blue: #EBEFF4;
 
 $light-gray: rgba(0,0,0,0.15); //box shadow
-$dark-gray: #2F2F2F; //typography and border
-$med-gray: #5B5B5B; //help and placeholder text
+$dark-gray: #2F2F2F;
+$med-gray: #5B5B5B;
 $light-med-gray: #A9A9A9; //button border
 $orange-gray: #BCBAB4; //tile border
-$neutral-sand: #E3E1DD; //footer background and border
+$neutral-sand: #E3E1DD;
 $lighter-gray: #EDEDEB; //button hover
-$off-white: #F6F6F4; //footer and button text and tile background
-$pure-white: #FFFFFF; //skip link text, input background, button text, modal background, modal title
-
-
+$off-white: #F6F6F4;
+$pure-white: #FFFFFF;
 
 
 // Layout

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -21,7 +21,6 @@ $pale-blue: #EBEFF4; //background
 
 $light-gray: rgba(0,0,0,0.15); //box shadow
 $dark-gray: #2F2F2F; //typography and border
-$med-dark-gray: #525252; //button color and nav border
 $med-gray: #5B5B5B; //help and placeholder text
 $light-med-gray: #A9A9A9; //button border
 $orange-gray: #BCBAB4; //tile border

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -16,8 +16,6 @@ $pale-blue: #EBEFF4;
 $deep-blue: #1A5096;
 $dark-blue: #113768;
 
-
-$dim-gray: #626262; //placeholder text
 $lighter-gray: #EDEDEB;
 $light-gray: rgba(0,0,0,0.15);
 $light-grayish-yellow: #F8F8F7; //DIMES Homepage background

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -18,7 +18,6 @@ $deep-blue: #1A5096; //button background and border, dropdown hover
 $light-blue: #C6D2DE; //facet border and button border
 $pale-blue: #EBEFF4; //background
 
-
 $light-gray: rgba(0,0,0,0.15); //box shadow
 $dark-gray: #2F2F2F; //typography and border
 $med-gray: #5B5B5B; //help and placeholder text
@@ -26,7 +25,6 @@ $light-med-gray: #A9A9A9; //button border
 $orange-gray: #BCBAB4; //tile border
 $neutral-sand: #E3E1DD; //footer background and border
 $lighter-gray: #EDEDEB; //button hover
-$light-grayish-yellow: #F8F8F7; //modal form background and homepage background
 $off-white: #F6F6F4; //footer and button text and tile background
 $pure-white: #FFFFFF; //skip link text, input background, button text, modal background, modal title
 


### PR DESCRIPTION
Cleans up color variables, fixes #59.

- Replaces dim-gray,  med-dark-gray, and light-grayish-yellow with similar colors used with rockarch.org.
- Implements background color on homepage.
- Cleans up styles to always use variables.

One color, `$deep-brown: #662700`, is currently not being used. I held off on deleting it because it's used in rockarch.org and I didn't want to take it out out of the palette just yet.

I confirmed that the burnt-orange (#D8531E) and red-orange (#F16943) buttons used with off-white and pure-white text mostly pass the WCAG 2.0 AA color contrast standard because the text is either bold or a large font, except for the hit counts. I made those bold, so I'd appreciate another eye to make sure that looks ok.