### PR TITLE
Update noteText helper to use note types rather than titles

### DIFF
--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -12,8 +12,8 @@ export const hasAccessAndUse = notes => {
 }
 
 
-/** Returns text for a specific note by title */
-export const noteText = (notes, noteTitle) => {
-  let note = notes && notes.filter(n => {return n.title === noteTitle})[0]
+/** Returns text for a specific note by type */
+export const noteText = (notes, noteType) => {
+  let note = notes && notes.filter(n => {return n.type === noteType})[0]
   return note ? note.subnotes.map(s => s.content).join("\r\n") : null
 }

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -119,7 +119,7 @@ const RecordsDetail = ({ activeRecords, ancestors, isAncestorsLoading, isContent
                 isLoading={isAncestorsLoading} />
               <PanelTextSection
                 title="Description"
-                text={noteText("abstract") || noteText("scopecontent")} />
+                text={noteText(activeRecords.notes, "abstract") || noteText(activeRecords.notes, "scopecontent")} />
               </>
               )
             }

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -119,7 +119,7 @@ const RecordsDetail = ({ activeRecords, ancestors, isAncestorsLoading, isContent
                 isLoading={isAncestorsLoading} />
               <PanelTextSection
                 title="Description"
-                text={noteText(activeRecords.notes, "Scope and Contents")} />
+                text={noteText("abstract") || noteText("scopecontent")} />
               </>
               )
             }
@@ -133,10 +133,10 @@ const RecordsDetail = ({ activeRecords, ancestors, isAncestorsLoading, isContent
           <AccordionItemPanel className="accordion__panel">
             <PanelTextSection
               title="Access"
-              text={noteText(activeRecords.notes, "Conditions Governing Access")} />
+              text={noteText(activeRecords.notes, "accessrestrict")} />
             <PanelTextSection
               title="Reproduction and Duplication"
-              text={noteText(activeRecords.notes, "Conditions Governing Use")} />
+              text={noteText(activeRecords.notes, "userestrict")} />
           </AccordionItemPanel>
         </AccordionItem>) :
         (null)}


### PR DESCRIPTION
Uses note types rather than titles, which allows for more accurate targeting of notes. Fixes #131 