### PR TITLE
Opens fee schedule in new window

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -283,7 +283,14 @@ export const DuplicationRequestModal = props => (
             component="textarea"
             rows={5} />
           <FormGroup
-            label={<>I agree to pay the duplication costs for this request. See our <a href="https://rockarch.org/collections/access-and-request-materials/#duplication-services-and-fee-schedule">fee schedule</a></>}
+            label={<>
+              I agree to pay the duplication costs for this request. See our
+              <a target="_blank"
+                 rel="noopener noreferrer"
+                 title="opens in a new window"
+                 href="https://rockarch.org/collections/access-and-request-materials/#duplication-services-and-fee-schedule">
+                 fee schedule
+              </a></>}
             name="costs"
             type="checkbox"
             required={true}

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -284,13 +284,13 @@ export const DuplicationRequestModal = props => (
             rows={5} />
           <FormGroup
             label={<>
-              I agree to pay the duplication costs for this request. See our
+              I agree to pay the duplication costs for this request. See our&nbsp;
               <a target="_blank"
-                 rel="noopener noreferrer"
-                 title="opens in a new window"
-                 href="https://rockarch.org/collections/access-and-request-materials/#duplication-services-and-fee-schedule">
-                 fee schedule
-              </a></>}
+                rel="noopener noreferrer"
+                title="opens in a new window"
+                href="https://rockarch.org/collections/access-and-request-materials/#duplication-services-and-fee-schedule">
+                fee schedule
+              </a>.</>}
             name="costs"
             type="checkbox"
             required={true}


### PR DESCRIPTION
Uses `target="_blank"` to open link in new tab or window. Also adds `title` attribute for accessibility and `rel=noopener` as recommended [here](https://mathiasbynens.github.io/rel-noopener/).

fixes #144 