### PR TITLE
Adds confirmation modals

### DIFF
--- a/src/components/Modal/styles.scss
+++ b/src/components/Modal/styles.scss
@@ -1,1 +1,0 @@
-@import "../../styles/components/modal";

--- a/src/components/ModalConfirm/__tests__/ModalConfirm.test.js
+++ b/src/components/ModalConfirm/__tests__/ModalConfirm.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import {render} from 'react-dom';
+import ModalConfirm from '..';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(<ModalConfirm
+      appElement={div}
+      isOpen={true}
+      message="foo"
+      title="Bar"
+      toggleModal={function(){}} />, div);
+});

--- a/src/components/ModalConfirm/index.js
+++ b/src/components/ModalConfirm/index.js
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Modal from "react-modal";
+import MaterialIcon from "../MaterialIcon";
+import "./styles.scss"
+
+
+const ModalConfirm = props => (
+  <Modal
+    appElement={props.appElement ? props.appElement : Modal.setAppElement("#root")}
+    isOpen={props.isOpen}
+    onRequestClose={props.toggleModal}
+    className="modal-content--confirm"
+    overlayClassName="modal-overlay">
+    <div className="modal-header">
+      <h2 className="modal-header__title">{props.title}</h2>
+      <button className="modal-header__button" aria-label="Close" onClick={props.toggleModal}>
+        <MaterialIcon icon="close"/>
+      </button>
+    </div>
+    <div className="modal-body">
+      <div className="modal-message">
+        <p>{props.message}</p>
+      </div>
+    </div>
+  </Modal>
+)
+
+ModalConfirm.propTypes = {
+  appElement: PropTypes.object,
+  handleChange: PropTypes.func,
+  isOpen: PropTypes.bool.isRequired,
+  message: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+}
+
+export default ModalConfirm

--- a/src/components/ModalConfirm/styles.scss
+++ b/src/components/ModalConfirm/styles.scss
@@ -1,0 +1,2 @@
+@import "../../styles/components/modal-base";
+@import "../../styles/components/modal-confirm";

--- a/src/components/ModalMyList/__tests__/ModalMyList.test.js
+++ b/src/components/ModalMyList/__tests__/ModalMyList.test.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import {render} from 'react-dom';
-import { CollectionHitsModal, DuplicationRequestModal, EmailModal, FacetModal, ReadingRoomRequestModal } from '..';
+import { DuplicationRequestModal, EmailModal, ReadingRoomRequestModal } from '..';
 
 import { resolvedList } from '../../../__fixtures__/resolvedList';
 import { submitList } from '../../../__fixtures__/submitList';
-import { collectionWithChildHits } from '../../../__fixtures__/collection';
-import { facet } from '../../../__fixtures__/facet';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
@@ -40,26 +38,5 @@ it('renders without crashing', () => {
       list={resolvedList}
       loadListData={function(){}}
       submitList={submitList}
-      toggleModal={function(){}} />, div);
-});
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  render(<CollectionHitsModal
-      appElement={div}
-      isOpen={true}
-      data={collectionWithChildHits}
-      toggleModal={function(){}} />, div);
-});
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  render(<FacetModal
-      appElement={div}
-      handleChange={function(){}}
-      handleDateChange={function(){}}
-      isOpen={true}
-      params={{}}
-      data={{}}
       toggleModal={function(){}} />, div);
 });

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -287,14 +287,14 @@ export const DuplicationRequestModal = props => (
             component="textarea"
             rows={5} />
           <FormGroup
-            label={<>
-              I agree to pay the duplication costs for this request. See our&nbsp;
+            label={[
+              "I agree to pay the duplication costs for this request. See our ",
               <a target="_blank"
                 rel="noopener noreferrer"
                 title="opens in a new window"
                 href="https://rockarch.org/collections/access-and-request-materials/#duplication-services-and-fee-schedule">
                 fee schedule
-              </a>.</>}
+              </a>, "."]}
             name="costs"
             type="checkbox"
             required={true}

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -1,19 +1,15 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import PropTypes from "prop-types";
 import Modal from "react-modal";
-import Button from "../Button";
 import Captcha from "../Captcha";
-import CollectionHits from "../CollectionHits";
-import Facet from "../Facet";
 import { FocusError, FormButtons, FormGroup } from "../Form";
-import { CheckBoxInput, YearInput } from "../Inputs";
 import MaterialIcon from "../MaterialIcon";
 import { ModalSavedItemList } from "../SavedItem";
 import "./styles.scss"
 
 
-const MyListModal = (props) => (
+const ModalMyList = (props) => (
   <Modal
     appElement={props.appElement ? props.appElement : Modal.setAppElement("#root")}
     isOpen={props.isOpen}
@@ -37,7 +33,7 @@ const MyListModal = (props) => (
   </Modal>
 )
 
-MyListModal.propTypes = {
+ModalMyList.propTypes = {
   appElement: PropTypes.object,
   handleChange: PropTypes.func,
   isOpen: PropTypes.bool.isRequired,
@@ -47,7 +43,7 @@ MyListModal.propTypes = {
 }
 
 export const EmailModal = props => (
-  <MyListModal
+  <ModalMyList
     appElement={props.appElement}
     title="Email List"
     handleChange={props.handleChange}
@@ -131,7 +127,7 @@ EmailModal.propTypes = {
 }
 
 export const ReadingRoomRequestModal = props => (
-  <MyListModal
+  <ModalMyList
     appElement={props.appElement}
     title="Request in Reading Room"
     handleChange={props.handleChange}
@@ -213,7 +209,7 @@ ReadingRoomRequestModal.propTypes = {
 
 
 export const DuplicationRequestModal = props => (
-  <MyListModal
+  <ModalMyList
     appElement={props.appElement}
     title="Request Copies"
     handleChange={props.handleChange}
@@ -324,128 +320,5 @@ DuplicationRequestModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   list: PropTypes.array.isRequired,
   submitList: PropTypes.array.isRequired,
-  toggleModal: PropTypes.func.isRequired,
-}
-
-export const FacetModal = props => {
-  var [startYear, setStartYear] = useState(0);
-  var [endYear, setEndYear] = useState(0);
-
-  useEffect(() => {
-    const startDate = (props.params.start_date__gte ? props.params.start_date__gte : (props.data.min_date && props.data.min_date.value)) || "";
-    const endDate = (props.params.end_date__lte ? props.params.end_date__lte : (props.data.max_date && props.data.max_date.value)) || "";
-    setStartYear(startDate);
-    setEndYear(endDate);
-  }, [props.params.start_date__gte, props.params.end_date__lte, props.data.min_date, props.data.max_date] );
-
-  return (
-    <Modal
-      appElement={props.appElement ? props.appElement : Modal.setAppElement("#root")}
-      isOpen={props.isOpen}
-      onRequestClose={props.toggleModal}
-      className="modal-content--facet"
-      overlayClassName={{
-        base: "modal-overlay--facet slide--right",
-        afterOpen: "slide--right--after-open",
-        beforeClose: "slide--right--before-close"
-      }}
-      closeTimeoutMS={200} >
-      <div className="modal-header--search">
-        <h2 className="modal-header__title">Filter Search Results</h2>
-        <button className="modal-header__button" aria-label="Close" onClick={props.toggleModal}>
-          <MaterialIcon icon="close"/>
-        </button>
-      </div>
-      <div className="modal-body">
-        <Facet>
-          <CheckBoxInput
-            id="online"
-            name="true"
-            className="facet__input"
-            checked={props.params.online === "true"}
-            handleChange={e => props.handleChange(e, "online")}
-            label={`Show me digital materials only (${props.data.online && props.data.online.doc_count})`} />
-        </Facet>
-        <Facet title="Date Range">
-          <YearInput
-            id="startYear"
-            label="Start Year"
-            className="hide-label"
-            handleChange={e => {setStartYear(e.target.value)}}
-            value={startYear} />
-          <YearInput
-            id="endYear"
-            label="End Year"
-            className="hide-label"
-            handleChange={e => {setEndYear(e.target.value)}}
-            value={endYear} />
-          <Button className="btn--sm btn--blue" label="apply" handleClick={() => {props.handleDateChange(startYear, endYear)}}/>
-        </Facet>
-        <Facet
-          handleChange={props.handleChange}
-          items={props.data.format}
-          paramKey="genre"
-          params={props.params.genre}
-          title="Format" />
-        <Facet
-          handleChange={props.handleChange}
-          items={props.data.creator}
-          paramKey="creator"
-          params={props.params.creator}
-          title="Creator" />
-        <Facet
-          handleChange={props.handleChange}
-          items={props.data.subject}
-          paramKey="subject"
-          params={props.params.subject}
-          title="Subject" />
-      </div>
-    </Modal>
-  )
-}
-
-FacetModal.propTypes = {
-  appElement: PropTypes.object,
-  data: PropTypes.object.isRequired,
-  handleChange: PropTypes.func.isRequired,
-  handleDateChange: PropTypes.func.isRequired,
-  isOpen: PropTypes.bool.isRequired,
-  params: PropTypes.object.isRequired,
-  toggleModal: PropTypes.func.isRequired,
-}
-
-export const CollectionHitsModal = props => {
-  return (
-    <Modal
-      appElement={props.appElement ? props.appElement : Modal.setAppElement("#root")}
-      isOpen={props.isOpen}
-      onRequestClose={props.toggleModal}
-      className="modal-content--hits"
-      overlayClassName={{
-        base: "modal-overlay--hits slide--left",
-        afterOpen: "slide--left--after-open",
-        beforeClose: "slide--left--before-close"
-      }}
-      closeTimeoutMS={200} >
-      <div className="modal-header--search">
-        <h2 className="modal-header__title">Inside This Collection</h2>
-        <button className="modal-header__button" aria-label="Close" onClick={props.toggleModal}>
-          <MaterialIcon icon="close"/>
-        </button>
-      </div>
-      <div className="modal-body">
-        <CollectionHits
-          collection={props.data}
-          isLoading={props.isLoading}
-          params={props.params} />
-      </div>
-    </Modal>
-  )
-}
-
-CollectionHitsModal.propTypes = {
-  appElement: PropTypes.object,
-  data: PropTypes.object.isRequired,
-  isOpen: PropTypes.bool.isRequired,
   toggleModal: PropTypes.func.isRequired,
 }

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -27,6 +27,7 @@ const ModalMyList = (props) => (
         <ModalSavedItemList items={props.list} handleChange={props.handleChange} />
       </div>
       <div className="modal-form">
+        {props.formIntro && <div className="modal-form__intro">{props.formIntro}</div>}
         {props.form}
       </div>
     </div>
@@ -221,6 +222,10 @@ export const DuplicationRequestModal = props => (
     isOpen={props.isOpen}
     toggleModal={props.toggleModal}
     list={props.list}
+    formIntro={[
+      <strong>Please note:</strong>,
+      " if you want a cost estimate for your order, email an archivist at ",
+      <a href="mailto:archive@rockarch.org">archive@rockarch.org</a>, "."]}
     form={
       <Formik
         initialValues={{

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -69,7 +69,9 @@ export const EmailModal = props => (
         }}
         onSubmit={(values, { setSubmitting }) => {
           props.handleFormSubmit(
-            `${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/api/deliver-request/email`, values, "email");
+            `${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/api/deliver-request/email`,
+            values,
+            "email");
           setSubmitting(false);
         }}
       >
@@ -144,7 +146,10 @@ export const ReadingRoomRequestModal = props => (
           return errors;
         }}
         onSubmit={(values, { setSubmitting }) => {
-          props.handleFormSubmit(`${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/api/deliver-request/reading-room`, values, "readingRoom");
+          props.handleFormSubmit(
+            `${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/api/deliver-request/reading-room`,
+            values,
+            "readingRoom");
           setSubmitting(false);
         }}
       >
@@ -234,7 +239,10 @@ export const DuplicationRequestModal = props => (
           return errors;
         }}
         onSubmit={(values, { setSubmitting }) => {
-          props.handleFormSubmit(`${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/api/deliver-request/duplication`, values, "duplication");
+          props.handleFormSubmit(
+            `${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/api/deliver-request/duplication`,
+            values,
+            "duplication");
           setSubmitting(false);
         }}
       >

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -27,7 +27,6 @@ const ModalMyList = (props) => (
         <ModalSavedItemList items={props.list} handleChange={props.handleChange} />
       </div>
       <div className="modal-form">
-        {props.formIntro && <div className="modal-form__intro">{props.formIntro}</div>}
         {props.form}
       </div>
     </div>
@@ -216,98 +215,103 @@ export const DuplicationRequestModal = props => (
     toggleModal={props.toggleModal}
     list={props.list}
     formIntro={[
-      <strong>Please note:</strong>,
-      " if you want a cost estimate for your order, email an archivist at ",
-      <a href="mailto:archive@rockarch.org">archive@rockarch.org</a>, "."]}
+      ]}
     form={
-      <Formik
-        initialValues={{
-          format: "",
-          description: "Entire folder",
-          questions: "",
-          notes: "",
-          costs: false,
-          items: props.submitList,
-          recaptcha: ""}}
-        validate={values => {
-          const errors = {};
-          if (!values.format) errors.format = 'Please select your desired duplication format.';
-          if (!values.recaptcha) errors.recaptcha = 'Please complete this field.';
-          if (!values.costs) errors.costs = "We cannot process your request unless you agree to pay the costs of reproduction.";
-          return errors;
-        }}
-        onSubmit={(values, { setSubmitting }) => {
-          props.handleFormSubmit(
-            `${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/api/deliver-request/duplication`,
-            values,
-            "duplication");
-          setSubmitting(false);
-        }}
-      >
-      {({ errors, isSubmitting, setFieldValue, touched }) => (
-        <Form>
-          <Field
-            type="hidden"
-            name="items"
-            value={props.submitList} />
-          <FormGroup
-            label="Format *"
-            name="format"
-            component="select"
-            children={[
-              <option key="1" value="">Select a format</option>,
-              <option key="2" value="JPEG">JPEG</option>,
-              <option key="3" value="PDF">PDF</option>,
-              <option key="4" value="Photocopy">Photocopy</option>,
-              <option key="5" value="TIFF">TIFF</option>]}
-            required={true}
-            errors={errors}
-            touched={touched} />
-          <FormGroup
-            label="Description of Materials"
-            helpText="Please describe the materials you want reproduced. 255 characters maximum."
-            name="description"
-            maxLength={255}
-            component="textarea"
-            rows={5} />
-          <FormGroup
-            label="Message for RAC staff"
-            helpText="255 characters maximum."
-            maxLength={255}
-            name="questions"
-            component="textarea"
-            rows={5} />
-          <FormGroup
-            label={[
-              "I agree to pay the duplication costs for this request. See our ",
-              <a target="_blank"
-                rel="noopener noreferrer"
-                title="opens in a new window"
-                href="https://rockarch.org/collections/access-and-request-materials/#duplication-services-and-fee-schedule">
-                fee schedule
-              </a>, "."]}
-            name="costs"
-            type="checkbox"
-            required={true}
-            errors={errors}
-            touched={touched} />
-          <Field
-            component={Captcha}
-            name="recaptcha"
-            handleCaptchaChange={(response) => setFieldValue("recaptcha", response)} />
-          <ErrorMessage
-            id="captcha-error"
-            name="recaptcha"
-            component="div"
-            className="modal-form__error" />
-          <FormButtons
-            submitText={`Request ${props.submitList.length ? (props.submitList.length) : "0"} ${props.submitList.length !== 1 ? "Items" : "Item"}`}
-            toggleModal={props.toggleModal}
-            isSubmitting={isSubmitting} />
-          <FocusError />
-        </Form>
-      )}
-      </Formik>
+      <>
+        <div className="modal-form__intro">
+          <strong>Please note:</strong> if you want a cost estimate for your order, email an archivist at <a href="mailto:archive@rockarch.org">archive@rockarch.org</a>.
+        </div>
+        <Formik
+          initialValues={{
+            format: "",
+            description: "Entire folder",
+            questions: "",
+            notes: "",
+            costs: false,
+            items: props.submitList,
+            recaptcha: ""}}
+          validate={values => {
+            const errors = {};
+            if (!values.format) errors.format = 'Please select your desired duplication format.';
+            if (!values.recaptcha) errors.recaptcha = 'Please complete this field.';
+            if (!values.costs) errors.costs = "We cannot process your request unless you agree to pay the costs of reproduction.";
+            return errors;
+          }}
+          onSubmit={(values, { setSubmitting }) => {
+            props.handleFormSubmit(
+              `${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/api/deliver-request/duplication`,
+              values,
+              "duplication");
+            setSubmitting(false);
+          }}
+        >
+        {({ errors, isSubmitting, setFieldValue, touched }) => (
+          <Form>
+            <Field
+              type="hidden"
+              name="items"
+              value={props.submitList} />
+            <div className="select__modal">
+              <FormGroup
+                label="Format *"
+                name="format"
+                component="select"
+                children={[
+                  <option key="1" value="">Select a format</option>,
+                  <option key="2" value="JPEG">JPEG</option>,
+                  <option key="3" value="PDF">PDF</option>,
+                  <option key="4" value="Photocopy">Photocopy</option>,
+                  <option key="5" value="TIFF">TIFF</option>]}
+                required={true}
+                errors={errors}
+                touched={touched} />
+            </div>
+            <FormGroup
+              label="Description of Materials"
+              helpText="Please describe the materials you want reproduced. 255 characters maximum."
+              name="description"
+              maxLength={255}
+              component="textarea"
+              rows={5} />
+            <FormGroup
+              label="Message for RAC staff"
+              helpText="255 characters maximum."
+              maxLength={255}
+              name="questions"
+              component="textarea"
+              rows={5} />
+            <FormGroup
+              label={[
+                "I agree to pay the duplication costs for this request. See our ",
+                <a target="_blank"
+                  rel="noopener noreferrer"
+                  title="opens in a new window"
+                  href="https://rockarch.org/collections/access-and-request-materials/#duplication-services-and-fee-schedule">
+                  fee schedule
+                </a>, "."]}
+              name="costs"
+              type="checkbox"
+              required={true}
+              errors={errors}
+              touched={touched} />
+            <Field
+              component={Captcha}
+              name="recaptcha"
+              handleCaptchaChange={(response) => setFieldValue("recaptcha", response)} />
+            <ErrorMessage
+              id="captcha-error"
+              name="recaptcha"
+              component="div"
+              className="modal-form__error" />
+            <FormButtons
+              submitText={`Request ${props.submitList.length ? (props.submitList.length) : "0"} ${props.submitList.length !== 1 ? "Items" : "Item"}`}
+              toggleModal={props.toggleModal}
+              isSubmitting={isSubmitting} />
+            <FocusError />
+          </Form>
+        )}
+        </Formik>
+      </>
     }
   />
 )

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -281,14 +281,14 @@ export const DuplicationRequestModal = props => (
               component="textarea"
               rows={5} />
             <FormGroup
-              label={[
-                "I agree to pay the duplication costs for this request. See our ",
+              label={<>
+                I agree to pay the duplication costs for this request. See our&nbsp;
                 <a target="_blank"
                   rel="noopener noreferrer"
                   title="opens in a new window"
                   href="https://rockarch.org/collections/access-and-request-materials/#duplication-services-and-fee-schedule">
                   fee schedule
-                </a>, "."]}
+                </a>.</>}
               name="costs"
               type="checkbox"
               required={true}

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -169,16 +169,9 @@ export const ReadingRoomRequestModal = props => (
             errors={errors}
             touched={touched} />
           <FormGroup
-            label="Special Requests/Questions for RAC staff"
+            label="Message for RAC staff"
             helpText="255 characters maximum"
             name="questions"
-            maxLength={255}
-            component="textarea"
-            rows={5} />
-          <FormGroup
-            label="Notes for Personal Reference"
-            helpText="255 characters maximum"
-            name="notes"
             maxLength={255}
             component="textarea"
             rows={5} />
@@ -278,17 +271,10 @@ export const DuplicationRequestModal = props => (
             component="textarea"
             rows={5} />
           <FormGroup
-            label="Special Requests/Questions for RAC staff"
+            label="Message for RAC staff"
             helpText="255 characters maximum."
             maxLength={255}
             name="questions"
-            component="textarea"
-            rows={5} />
-          <FormGroup
-            label="Notes for Personal Reference"
-            helpText="255 characters maximum."
-            maxLength={255}
-            name="notes"
             component="textarea"
             rows={5} />
           <FormGroup

--- a/src/components/ModalMyList/styles.scss
+++ b/src/components/ModalMyList/styles.scss
@@ -1,0 +1,2 @@
+@import "../../styles/components/modal-base";
+@import "../../styles/components/modal-mylist";

--- a/src/components/ModalSearch/__tests__/ModalSearch.test.js
+++ b/src/components/ModalSearch/__tests__/ModalSearch.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import {render} from 'react-dom';
+import { CollectionHitsModal, FacetModal } from '..';
+
+import { collectionWithChildHits } from '../../../__fixtures__/collection';
+import { facet } from '../../../__fixtures__/facet';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(<CollectionHitsModal
+      appElement={div}
+      isOpen={true}
+      data={collectionWithChildHits}
+      toggleModal={function(){}} />, div);
+});
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(<FacetModal
+      appElement={div}
+      handleChange={function(){}}
+      handleDateChange={function(){}}
+      isOpen={true}
+      params={{}}
+      data={{}}
+      toggleModal={function(){}} />, div);
+});

--- a/src/components/ModalSearch/index.js
+++ b/src/components/ModalSearch/index.js
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import Modal from "react-modal";
+import Button from "../Button";
+import CollectionHits from "../CollectionHits";
+import Facet from "../Facet";
+import { CheckBoxInput, YearInput } from "../Inputs";
+import MaterialIcon from "../MaterialIcon";
+import "./styles.scss"
+
+
+export const FacetModal = props => {
+  var [startYear, setStartYear] = useState(0);
+  var [endYear, setEndYear] = useState(0);
+
+  useEffect(() => {
+    const startDate = (props.params.start_date__gte ? props.params.start_date__gte : (props.data.min_date && props.data.min_date.value)) || "";
+    const endDate = (props.params.end_date__lte ? props.params.end_date__lte : (props.data.max_date && props.data.max_date.value)) || "";
+    setStartYear(startDate);
+    setEndYear(endDate);
+  }, [props.params.start_date__gte, props.params.end_date__lte, props.data.min_date, props.data.max_date] );
+
+  return (
+    <Modal
+      appElement={props.appElement ? props.appElement : Modal.setAppElement("#root")}
+      isOpen={props.isOpen}
+      onRequestClose={props.toggleModal}
+      className="modal-content--facet"
+      overlayClassName={{
+        base: "modal-overlay--facet slide--right",
+        afterOpen: "slide--right--after-open",
+        beforeClose: "slide--right--before-close"
+      }}
+      closeTimeoutMS={200} >
+      <div className="modal-header--search">
+        <h2 className="modal-header__title">Filter Search Results</h2>
+        <button className="modal-header__button" aria-label="Close" onClick={props.toggleModal}>
+          <MaterialIcon icon="close"/>
+        </button>
+      </div>
+      <div className="modal-body">
+        <Facet>
+          <CheckBoxInput
+            id="online"
+            name="true"
+            className="facet__input"
+            checked={props.params.online === "true"}
+            handleChange={e => props.handleChange(e, "online")}
+            label={`Show me digital materials only (${props.data.online && props.data.online.doc_count})`} />
+        </Facet>
+        <Facet title="Date Range">
+          <YearInput
+            id="startYear"
+            label="Start Year"
+            className="hide-label"
+            handleChange={e => {setStartYear(e.target.value)}}
+            value={startYear} />
+          <YearInput
+            id="endYear"
+            label="End Year"
+            className="hide-label"
+            handleChange={e => {setEndYear(e.target.value)}}
+            value={endYear} />
+          <Button className="btn--sm btn--blue" label="apply" handleClick={() => {props.handleDateChange(startYear, endYear)}}/>
+        </Facet>
+        <Facet
+          handleChange={props.handleChange}
+          items={props.data.format}
+          paramKey="genre"
+          params={props.params.genre}
+          title="Format" />
+        <Facet
+          handleChange={props.handleChange}
+          items={props.data.creator}
+          paramKey="creator"
+          params={props.params.creator}
+          title="Creator" />
+        <Facet
+          handleChange={props.handleChange}
+          items={props.data.subject}
+          paramKey="subject"
+          params={props.params.subject}
+          title="Subject" />
+      </div>
+    </Modal>
+  )
+}
+
+FacetModal.propTypes = {
+  appElement: PropTypes.object,
+  data: PropTypes.object.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  handleDateChange: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  params: PropTypes.object.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+}
+
+export const CollectionHitsModal = props => {
+  return (
+    <Modal
+      appElement={props.appElement ? props.appElement : Modal.setAppElement("#root")}
+      isOpen={props.isOpen}
+      onRequestClose={props.toggleModal}
+      className="modal-content--hits"
+      overlayClassName={{
+        base: "modal-overlay--hits slide--left",
+        afterOpen: "slide--left--after-open",
+        beforeClose: "slide--left--before-close"
+      }}
+      closeTimeoutMS={200} >
+      <div className="modal-header--search">
+        <h2 className="modal-header__title">Inside This Collection</h2>
+        <button className="modal-header__button" aria-label="Close" onClick={props.toggleModal}>
+          <MaterialIcon icon="close"/>
+        </button>
+      </div>
+      <div className="modal-body">
+        <CollectionHits
+          collection={props.data}
+          isLoading={props.isLoading}
+          params={props.params} />
+      </div>
+    </Modal>
+  )
+}
+
+CollectionHitsModal.propTypes = {
+  appElement: PropTypes.object,
+  data: PropTypes.object.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+}

--- a/src/components/ModalSearch/styles.scss
+++ b/src/components/ModalSearch/styles.scss
@@ -1,0 +1,2 @@
+@import "../../styles/components/modal-base";
+@import "../../styles/components/modal-search";

--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -154,11 +154,13 @@
           if (modal === "email") {
             message = `Selected items in your list have been emailed to ${submitted.email}`
           } else if (modal === "duplication") {
-            message = ["Your requests have been submitted to ",
-                       <a href='https://raccess.rockarch.org'>RACcess</a>, "."]
+            message = ["Your requests have been submitted to",
+                       <a href='https://raccess.rockarch.org'>RACcess</a>, ". ",
+                       "You can track their status using your RACcess account."]
           } else {
             message = ["Your requests have been submitted to ",
-                       <a href='https://raccess.rockarch.org'>RACcess</a>, ".",
+                       <a href='https://raccess.rockarch.org'>RACcess</a>, ". ",
+                       "You can track their status using your RACcess account.",
                        <br/ >, <br />,
                        "Requests to access archival records in the Reading Room are processed between 10am-3pm on days when the Rockefeller Archive Center is open."]
           }
@@ -170,7 +172,7 @@
           // const title = "Error submitting request"
           // const message = `There was an error submitting your request. The error message was: ${err.toString()}`
           // this.handleConfirmData(title, message);
-          /** end commnted code */
+          /** end commented code */
         })
         .then(() => {
           /** added for testing purposes ONLY, should be removed once Request Broker is in place */
@@ -180,10 +182,12 @@
             message = `Selected items in your list have been emailed to ${submitted.email}`
           } else if (modal === "duplication") {
             message = ["Your requests have been submitted to ",
-                       <a href='https://raccess.rockarch.org'>RACcess</a>, "."]
+                       <a href='https://raccess.rockarch.org'>RACcess</a>, ". ",
+                       "You can track their status using your RACcess account."]
           } else {
             message = ["Your requests have been submitted to ",
-                       <a href='https://raccess.rockarch.org'>RACcess</a>, ".",
+                       <a href='https://raccess.rockarch.org'>RACcess</a>, ". ",
+                       "You can track their status using your RACcess account.",
                        <br/ >, <br />,
                        "Requests to access archival records in the Reading Room are processed between 10am-3pm on days when the Rockefeller Archive Center is open."]
           }

--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -4,7 +4,7 @@
   import { Helmet } from "react-helmet";
   import Button from "../Button";
   import { MyListDropdown } from "../Dropdown";
-  import { DuplicationRequestModal, EmailModal, ReadingRoomRequestModal } from "../Modal";
+  import { DuplicationRequestModal, EmailModal, ReadingRoomRequestModal } from "../ModalMyList";
   import { SavedItemList } from "../SavedItem";
   import "./styles.scss";
 

--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -5,6 +5,7 @@
   import Button from "../Button";
   import { MyListDropdown } from "../Dropdown";
   import { DuplicationRequestModal, EmailModal, ReadingRoomRequestModal } from "../ModalMyList";
+  import ModalConfirm from "../ModalConfirm";
   import { SavedItemList } from "../SavedItem";
   import "./styles.scss";
 
@@ -63,18 +64,23 @@
     constructor(props) {
       super(props);
       this.state = {
-        "savedList": [],
-        "modalList": [],
-        "submitList": [],
-        "isLoading": true,
-        "email": {
-          "isOpen": false
+        savedList: [],
+        modalList: [],
+        submitList: [],
+        isLoading: true,
+        email: {
+          isOpen: false
         },
-        "readingRoom": {
-          "isOpen": false
+        readingRoom: {
+          isOpen: false
         },
-        "duplication": {
-          "isOpen": false
+        duplication: {
+          isOpen: false
+        },
+        confirm: {
+          isOpen: false,
+          title: "",
+          message: ""
         }
       };
     }
@@ -132,14 +138,60 @@
       this.setState({modalList: filtered})
     }
 
+    handleConfirmData = (title, message) => {
+      this.setState({ confirm: { ...this.state.confirm, title: title, message: message } })
+    }
+
     handleFormSubmit = (uri, submitted, modal) => {
       // TODO: remove toggleModal, which is just here for testing purposes.
       this.toggleModal(modal);
       axios
         .post(uri, submitted)
-        .then(res => { this.toggleModal(modal); })
-        .catch(err => { console.log(err) }
-      );
+        .then(res => {
+          this.toggleModal(modal);
+          const title = modal === "email" ? "Email Sent" : "Requests Delivered"
+          var message = ""
+          if (modal === "email") {
+            message = `Selected items in your list have been emailed to ${submitted.email}`
+          } else if (modal === "duplication") {
+            message = ["Your requests have been submitted to ",
+                       <a href='https://raccess.rockarch.org'>RACcess</a>, "."]
+          } else {
+            message = ["Your requests have been submitted to ",
+                       <a href='https://raccess.rockarch.org'>RACcess</a>, ".",
+                       <br/ >, <br />,
+                       "Requests to access archival records in the Reading Room are processed between 10am-3pm on days when the Rockefeller Archive Center is open."]
+          }
+          this.handleConfirmData(title, message);
+        })
+        .catch(err => {
+          console.log(err)
+          /** the following lines commented out for testing purposes only */
+          // const title = "Error submitting request"
+          // const message = `There was an error submitting your request. The error message was: ${err.toString()}`
+          // this.handleConfirmData(title, message);
+          /** end commnted code */
+        })
+        .then(() => {
+          /** added for testing purposes ONLY, should be removed once Request Broker is in place */
+          const title = modal === "email" ? "Email Sent" : "Requests Delivered"
+          var message = ""
+          if (modal === "email") {
+            message = `Selected items in your list have been emailed to ${submitted.email}`
+          } else if (modal === "duplication") {
+            message = ["Your requests have been submitted to ",
+                       <a href='https://raccess.rockarch.org'>RACcess</a>, "."]
+          } else {
+            message = ["Your requests have been submitted to ",
+                       <a href='https://raccess.rockarch.org'>RACcess</a>, ".",
+                       <br/ >, <br />,
+                       "Requests to access archival records in the Reading Room are processed between 10am-3pm on days when the Rockefeller Archive Center is open."]
+          }
+          this.handleConfirmData(title, message);
+          /** end testing code */
+          this.toggleModal("confirm")
+        });
+
     }
 
     fetchFromUri = uri => {
@@ -279,6 +331,10 @@
             handleFormSubmit={this.handleFormSubmit}
             list={this.state.modalList}
             submitList={this.state.submitList}
+          />
+          <ModalConfirm
+            {...this.state.confirm}
+            toggleModal={() => this.toggleModal("confirm")}
           />
         </React.Fragment>
       );

--- a/src/components/PageSearch/index.js
+++ b/src/components/PageSearch/index.js
@@ -6,7 +6,7 @@ import { Helmet } from "react-helmet";
 import Button from "../Button";
 import { SelectInput, SelectOption } from "../Inputs"
 import { SearchSkeleton } from "../LoadingSkeleton";
-import { CollectionHitsModal, FacetModal } from "../Modal";
+import { CollectionHitsModal, FacetModal } from "../ModalSearch";
 import { SearchPagination } from "../Pagination";
 import SearchForm from "../SearchForm";
 import TileList from "../Tile";

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -9,14 +9,10 @@
 p, a {
   font-family: inherit;
   font-weight: $font-weight-normal;
-  font-size: 16px;
-  line-height: 26px;
+  font-size: inherit;
+  line-height: inherit;
   margin: 0 0 10px 0;
   color: $dark-gray;
-  @media screen and (min-width: $break-lg) {
-    font-size: 17px;
-    line-height: 28px;
-  }
 }
 
 strong, b {

--- a/src/styles/components/_modal-base.scss
+++ b/src/styles/components/_modal-base.scss
@@ -59,14 +59,6 @@
   background-color: $dark-gray;
   padding: 16px 20px 10px 20px;
   float: left;
-  width: calc(100% - #{$modal-content-margin});
-}
-
-.modal-header--search {
-  color: $deep-navy;
-  background-color: none;
-  padding: 30px 30px 40px 30px;
-  float: left;
   width: 100%;
   box-sizing: border-box;
 }

--- a/src/styles/components/_modal-base.scss
+++ b/src/styles/components/_modal-base.scss
@@ -53,30 +53,6 @@
   outline: none;
 }
 
-.modal-content--facet {
-  @extend .modal-content;
-  top: 0;
-  left: 0;
-  right: unset;
-  width: 420px;
-  height: 100vh;
-  border-radius: 0px;
-  border: 1px solid $dark-gray;
-  background: $pale-blue;
-}
-
-.modal-content--hits {
-  @extend .modal-content;
-  left: unset;
-  top: 0;
-  right: 0;
-  width: 420px;
-  height: 100vh;
-  border-radius: 0px;
-  border: 1px solid $dark-gray;
-  background: $pure-white;
-}
-
 .modal-header {
   font-family: $sans-serif-stack;
   color: $pure-white;
@@ -120,76 +96,4 @@
   @media screen and (min-width: $break-lg) {
     width: 100%
   }
-}
-
-.modal-list {
-  width: 100%;
-  float: left;
-  padding: 30px 20px;
-  box-sizing: border-box;
-  @media screen and (min-width: $break-lg) {
-    @include grid-column(8);
-  }
-}
-
-.modal-form {
-  float: left;
-  width: 100%;
-  height: 100%;
-  background-color: $off-white;
-  border-top: 1px solid $neutral-sand;
-  padding: 30px 20px;
-  box-sizing: border-box;
-  font-size: 14px;
-  margin-bottom: 18px;
-  @media screen and (min-width: $break-lg) {
-    @include grid-column(4);
-    float: right;
-  }
-}
-
-.modal-form input, textarea, select {
-  width: 100%;
-  border: 1px solid $dark-gray;
-  padding: 10px;
-  box-sizing: border-box;
-  &[type=checkbox] {
-    width: unset;
-    float: left;
-  }
-
-}
-
-.modal-form label {
-  margin-bottom: 5px;
-  margin-top: 10px;
-  float: left;
-  &[for=costs] {
-    float: none;
-    & a {
-      font-family: $sans-serif-stack;
-      font-size: 14px;
-    }
-  }
-}
-
-.modal-form .is-invalid {
-    border: 1px solid $burnt-orange;
-}
-
-.modal-form__buttons {
-  margin: 20px 0;
-}
-
-.modal-form__error {
-  border-radius: 3px;
-  border: 1px solid $burnt-orange;
-  font-family: $sans-serif-stack;
-  font-size: 13px;
-  font-style: italic;
-  display: block;
-  background: $light-orange;
-  color: $dark-gray;
-  margin: 10px 0px;
-  padding: 10px;
 }

--- a/src/styles/components/_modal-confirm.scss
+++ b/src/styles/components/_modal-confirm.scss
@@ -10,6 +10,12 @@
   border-radius: 3px;
   overflow: auto;
   outline: none;
+  @media screen and (min-width: $break-lg) {
+    top: $confirm-modal-content-margin-lg;
+    left: $confirm-modal-content-margin-lg;
+    right: $confirm-modal-content-margin-lg;
+    bottom: $confirm-modal-content-margin-lg;
+  }
 }
 
 .modal-message {

--- a/src/styles/components/_modal-confirm.scss
+++ b/src/styles/components/_modal-confirm.scss
@@ -1,0 +1,18 @@
+.modal-content--confirm {
+  font-family: $sans-serif-stack;
+  position: absolute;
+  top: $confirm-modal-content-margin;
+  left: $confirm-modal-content-margin;
+  right: $confirm-modal-content-margin;
+  bottom: $confirm-modal-content-margin;
+  border: 1px solid $dark-gray;
+  background: rgb(255, 255, 255);
+  border-radius: 3px;
+  overflow: auto;
+  outline: none;
+}
+
+.modal-message {
+  padding: 20px;
+  font-size: 18px;
+}

--- a/src/styles/components/_modal-mylist.scss
+++ b/src/styles/components/_modal-mylist.scss
@@ -28,7 +28,7 @@
   margin-bottom: 10px;
 }
 
-.modal-form input, textarea, select {
+.modal-form input, .modal-form textarea, .modal-form select {
   width: 100%;
   border: 1px solid $dark-gray;
   padding: 10px;
@@ -37,7 +37,20 @@
     width: unset;
     float: left;
   }
+}
 
+.select__modal {
+  position: relative;
+}
+
+.select__modal::after {
+  font-family: 'Material Icons';
+  content: "unfold_more";
+  font-size: 20px;
+  bottom: 8px;
+  right: 10px;
+  position: absolute;
+  pointer-events: none;
 }
 
 .modal-form label {

--- a/src/styles/components/_modal-mylist.scss
+++ b/src/styles/components/_modal-mylist.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.modal-form__intro {
+  margin-bottom: 10px;
+}
+
 .modal-form input, textarea, select {
   width: 100%;
   border: 1px solid $dark-gray;

--- a/src/styles/components/_modal-mylist.scss
+++ b/src/styles/components/_modal-mylist.scss
@@ -1,0 +1,71 @@
+.modal-list {
+  width: 100%;
+  float: left;
+  padding: 30px 20px;
+  box-sizing: border-box;
+  @media screen and (min-width: $break-lg) {
+    @include grid-column(8);
+  }
+}
+
+.modal-form {
+  float: left;
+  width: 100%;
+  height: 100%;
+  background-color: $off-white;
+  border-top: 1px solid $neutral-sand;
+  padding: 30px 20px;
+  box-sizing: border-box;
+  font-size: 14px;
+  margin-bottom: 18px;
+  @media screen and (min-width: $break-lg) {
+    @include grid-column(4);
+    float: right;
+  }
+}
+
+.modal-form input, textarea, select {
+  width: 100%;
+  border: 1px solid $dark-gray;
+  padding: 10px;
+  box-sizing: border-box;
+  &[type=checkbox] {
+    width: unset;
+    float: left;
+  }
+
+}
+
+.modal-form label {
+  margin-bottom: 5px;
+  margin-top: 10px;
+  float: left;
+  &[for=costs] {
+    float: none;
+    & a {
+      font-family: $sans-serif-stack;
+      font-size: 14px;
+    }
+  }
+}
+
+.modal-form .is-invalid {
+    border: 1px solid $burnt-orange;
+}
+
+.modal-form__buttons {
+  margin: 20px 0;
+}
+
+.modal-form__error {
+  border-radius: 3px;
+  border: 1px solid $burnt-orange;
+  font-family: $sans-serif-stack;
+  font-size: 13px;
+  font-style: italic;
+  display: block;
+  background: $light-orange;
+  color: $dark-gray;
+  margin: 10px 0px;
+  padding: 10px;
+}

--- a/src/styles/components/_modal-search.scss
+++ b/src/styles/components/_modal-search.scss
@@ -1,0 +1,32 @@
+.modal-content--facet {
+  @extend .modal-content;
+  top: 0;
+  left: 0;
+  right: unset;
+  width: 420px;
+  height: 100vh;
+  border-radius: 0px;
+  border: 1px solid $dark-gray;
+  background: $pale-blue;
+}
+
+.modal-content--hits {
+  @extend .modal-content;
+  left: unset;
+  top: 0;
+  right: 0;
+  width: 420px;
+  height: 100vh;
+  border-radius: 0px;
+  border: 1px solid $dark-gray;
+  background: $pure-white;
+}
+
+.modal-header--search {
+  color: $deep-navy;
+  background-color: none;
+  padding: 30px 30px 40px 30px;
+  float: left;
+  width: 100%;
+  box-sizing: border-box;
+}

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -44,3 +44,4 @@ $font-weight-light: 300;
 
 //Modals
 $modal-content-margin: 40px;
+$confirm-modal-content-margin: 200px;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -44,4 +44,5 @@ $font-weight-light: 300;
 
 //Modals
 $modal-content-margin: 40px;
-$confirm-modal-content-margin: 200px;
+$confirm-modal-content-margin: 125px;
+$confirm-modal-content-margin-lg: 225px;


### PR DESCRIPTION
Adds confirmation modals for MyList actions (email, reading room, duplication).

This functionality is currently being mocked so you can see the confirmation message. There are inline comments in `/src/components/PageMyList` in the `handleFormSubmit` method which indicate what needs to be changed once Request Broker is available. I'm also happy to make those changes once you've reviewed so that we merge only code that's working as intended - depends on future testing plans.

fixes #142 

Also addresses some minor issues with request modals:
- Adds cost estimate note to duplication form, fixes #157 
- Removes "Notes for Personal Reference" fields, fixes #155 
- Adds `unfold_more` icon to format select (and adds border), fixes #154 