### PR TITLE
Improves styling and behavior of details pane

### DIFF
--- a/src/components/LoadingSkeleton/index.js
+++ b/src/components/LoadingSkeleton/index.js
@@ -81,8 +81,6 @@ export const DetailSkeleton = () => (
     <ul className="panel__list--unstyled">
       <li><Skeleton /></li>
     </ul>
-    <h3 className="panel__heading"><Skeleton /></h3>
-    <p className="panel__text"><Skeleton /></p>
   </>
 )
 
@@ -91,9 +89,7 @@ export const FoundInItemSkeleton = () => (
     {Array(3)
       .fill()
       .map((item, index) => (
-        <li className="found-in__subcollection" key={index}>
-          <p className="found-in__link"><Skeleton /></p>
-        </li>
+        <p key={index} className="found-in__link"><Skeleton /></p>
       ))}
   </>
 )

--- a/src/components/PageRecords/index.js
+++ b/src/components/PageRecords/index.js
@@ -70,26 +70,28 @@ class PageRecords extends Component {
 
   /** Updates state with item found at URL. */
   setActiveRecords = uri => {
-    this.setState({isItemLoading: true})
-    this.setState({isAncestorsLoading: true})
-    const itemUrl = `${process.env.REACT_APP_ARGO_BASEURL}/${uri}`
-    axios
-      .get(`${itemUrl}?${queryString.stringify(this.state.params)}`)
-      .then(res => {
-        this.setState({ item: res.data });
-        this.setState({ updateMessage: `Details under heading 1 have been updated to describe the selected records titled ${res.data.title}`})
-        this.setUrl(`${uri}?${queryString.stringify(this.state.params)}`, res.data);
-      })
-      .catch(e => console.log(e))
-      .then(() => this.setState({isItemLoading: false}));
-    axios
-      .get(`${itemUrl}/ancestors?${queryString.stringify(this.state.params)}`)
-      .then(res => {
-        this.setState({ ancestors: res.data })
-      })
-      .catch(e => console.log(e))
-      .then(() => this.setState({isAncestorsLoading: false}));
-  }
+    if (uri !== this.state.item.uri) {
+      this.setState({isItemLoading: true})
+      this.setState({isAncestorsLoading: true})
+      const itemUrl = `${process.env.REACT_APP_ARGO_BASEURL}/${uri}`
+      axios
+        .get(`${itemUrl}?${queryString.stringify(this.state.params)}`)
+        .then(res => {
+          this.setState({ item: res.data });
+          this.setState({ updateMessage: `Details under heading 1 have been updated to describe the selected records titled ${res.data.title}`})
+          this.setUrl(`${uri}?${queryString.stringify(this.state.params)}`, res.data);
+        })
+        .catch(e => console.log(e))
+        .then(() => this.setState({isItemLoading: false}));
+      axios
+        .get(`${itemUrl}/ancestors?${queryString.stringify(this.state.params)}`)
+        .then(res => {
+          this.setState({ ancestors: res.data })
+        })
+        .catch(e => console.log(e))
+        .then(() => this.setState({isAncestorsLoading: false}));
+    }
+}
 
   /** Pushes a URL and state into browser history */
   setUrl = (uri, itemData) => {

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -43,14 +43,14 @@ const PanelFormatSection = ({ formats, notes }) => {
   const displayFormats = formats.filter(f => (
     f !== "documents"
   ))
-  const materialSpecificText = noteText(notes, "materialspec")
+  const materialSpecificText = (noteText(notes, "physdesc") || "").concat("\n", noteText(notes, "materialspec"))
   return (
     displayFormats.length ? (
       <div className="panel__section">
         <h3 className="panel__heading">Formats</h3>
         <ul className="panel__list--unstyled">
           {materialSpecificText ?
-            (<li>{materialSpecificText}</li>) :
+            (<li className="panel__text">{materialSpecificText}</li>) :
             (displayFormats.map((format, index) => (
               <li key={index} className="panel__text">{format}</li>))
             )

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -43,13 +43,13 @@ const PanelFormatSection = ({ formats, notes }) => {
   const displayFormats = formats.filter(f => (
     f !== "documents"
   ))
-  const materialSpecificText = (noteText(notes, "physdesc") || "").concat("\n", noteText(notes, "materialspec"))
+  const materialSpecificText = (noteText(notes, "physdesc") || "").concat("\n", noteText(notes, "materialspec" || ""))
   return (
     displayFormats.length ? (
       <div className="panel__section">
         <h3 className="panel__heading">Formats</h3>
         <ul className="panel__list--unstyled">
-          {materialSpecificText ?
+          {materialSpecificText && materialSpecificText !== "\nnull" ?
             (<li className="panel__text">{materialSpecificText}</li>) :
             (displayFormats.map((format, index) => (
               <li key={index} className="panel__text">{format}</li>))

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -39,17 +39,22 @@ const PanelExtentSection = ({ extents }) => (
   (null)
 )
 
-const PanelFormatSection = ({ formats }) => {
+const PanelFormatSection = ({ formats, notes }) => {
   const displayFormats = formats.filter(f => (
     f !== "documents"
   ))
+  const materialSpecificText = noteText(notes, "materialspec")
   return (
     displayFormats.length ? (
       <div className="panel__section">
         <h3 className="panel__heading">Formats</h3>
         <ul className="panel__list--unstyled">
-          {displayFormats.map((format, index) => (
-          <li key={index} className="panel__text">{format}</li>))}
+          {materialSpecificText ?
+            (<li>{materialSpecificText}</li>) :
+            (displayFormats.map((format, index) => (
+              <li key={index} className="panel__text">{format}</li>))
+            )
+          }
         </ul>
       </div>) :
     (null)
@@ -64,6 +69,18 @@ const PanelFoundInSection = ({ ancestors, isItemLoading }) => (
       {isItemLoading ?
         (<FoundInItemSkeleton/>) :
         (<FoundInItem item={ancestors} className="found-in__collection" />)}
+      </ul>
+    </div>) :
+    (null)
+)
+
+const PanelLinkedListSection = ({ listData, title }) =>  (
+  listData ?
+    (<div className="panel__section">
+      <h3 className="panel__heading">{title}</h3>
+      <ul className="panel__list--unstyled">
+        {listData.map((item, index) => (
+        <li key={index} className="panel__text"><a href={item.uri}>{item.title}</a></li>))}
       </ul>
     </div>) :
     (null)
@@ -85,7 +102,7 @@ const PanelTextSection = ({ text, title }) => (
   text ?
     (<div className="panel__section">
       <h3 className="panel__heading">{title}</h3>
-      <p className="panel__text">{text}</p>
+      <p className="panel__text--narrative">{text}</p>
     </div>) :
     (null)
 )
@@ -143,17 +160,18 @@ const RecordsDetail = ({ ancestors, isAncestorsLoading, isContentShown, isItemLo
           {isItemLoading ?
             (<DetailSkeleton />) :
             (<>
-              <PanelListSection
-                title="Creators"
-                listData={item.creators} />
-              <PanelTextSection
-                title="Dates"
-                text={dateString(item.dates)} />
               <div className="panel__section--flex">
+                <PanelLinkedListSection
+                  title="Creators"
+                  listData={item.creators} />
+                <PanelTextSection
+                  title="Dates"
+                  text={dateString(item.dates)} />
                 <PanelExtentSection
                   extents={item.extents} />
                 <PanelFormatSection
-                  formats={item.formats} />
+                  formats={item.formats}
+                  notes={item.notes} />
               </div>
               <PanelFoundInSection
                 ancestors={ancestors}

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -43,14 +43,17 @@ const PanelFormatSection = ({ formats, notes }) => {
   const displayFormats = formats.filter(f => (
     f !== "documents"
   ))
-  const materialSpecificText = (noteText(notes, "physdesc") || "").concat("\n", noteText(notes, "materialspec" || ""))
+  const formatText = []
+  formatText.push(noteText(notes, "physdesc"))
+  formatText.push(noteText(notes, "materialspec"))
+  const filteredFormatText = formatText.filter(i => (i != null))
   return (
     displayFormats.length ? (
       <div className="panel__section">
         <h3 className="panel__heading">Formats</h3>
         <ul className="panel__list--unstyled">
-          {materialSpecificText && materialSpecificText !== "\nnull" ?
-            (<li className="panel__text">{materialSpecificText}</li>) :
+          {filteredFormatText.length ?
+            (<li className="panel__text">{filteredFormatText.join("\n")}</li>) :
             (displayFormats.map((format, index) => (
               <li key={index} className="panel__text">{format}</li>))
             )

--- a/src/styles/components/_accordion.scss
+++ b/src/styles/components/_accordion.scss
@@ -50,6 +50,7 @@
   font-size: 15px;
   color: $dark-gray;
   line-height: inherit;
+  white-space: pre-line;
 }
 
 .panel__text a {

--- a/src/styles/components/_accordion.scss
+++ b/src/styles/components/_accordion.scss
@@ -37,15 +37,29 @@
 .panel__heading {
   font-family: inherit;
   font-size: 12px;
+  font-weight: 800;
   color: $dark-gray;
   letter-spacing: 0.7px;
   text-transform: uppercase;
+  margin-bottom: 5px;
+  margin-top: 10px;
 }
 
 .panel__text {
   font-family: inherit;
   font-size: 15px;
   color: $dark-gray;
+  line-height: inherit;
+}
+
+.panel__text a {
+  color: $dark-gray;
+  text-decoration: underline;
+  font-weight: normal;
+}
+
+.panel__text--narrative {
+  @extend .panel__text;
   line-height: 25px;
 }
 

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -40,10 +40,9 @@
 .panel__section--flex {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
   & .panel__section {
-  }
-  & .panel__section:not(:first-of-type) {
-    padding-left: 30px;
+    flex-shrink: 0;
   }
 }
 

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -33,14 +33,17 @@
   color: $deep-navy;
 }
 
+.panel__section {
+  box-sizing: border-box;
+}
+
 .panel__section--flex {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
+  & .panel__section {
+  }
   & .panel__section:not(:first-of-type) {
-    margin-left: 30px;
-    @media screen and (min-width: $break-md) {
-      margin-left: 40px;
-    }
+    padding-left: 30px;
   }
 }
 

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -41,9 +41,6 @@
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  & .panel__section {
-    flex-shrink: 0;
-  }
 }
 
 .found-in {


### PR DESCRIPTION
Makes a number of changes to improve the styling and behavior of the details component:
- compacts the display by showing all short attributes on a single row
- only loads data if it is different than data currently shown
- show line breaks in notes
- add physdesc information to formats

Fixes #172 