### PR TITLE
Updates `hasAccessOrUse` helper

### DIFF
--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -7,9 +7,9 @@ export const dateString = dates => {
 
 
 /** Boolean indicator for the presence of access and use notes */
-export const hasAccessAndUse = notes => {
-  const access = notes && notes.filter(n => {return n.title === "Conditions Governing Access"}).length
-  const use = notes && notes.filter(n => {return n.title === "Conditions Governing Use"}).length
+export const hasAccessOrUse = notes => {
+  const access = notes && notes.filter(n => {return n.type === "accessrestrict"}).length
+  const use = notes && notes.filter(n => {return n.type === "userestrict"}).length
   return access || use
 }
 

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -13,7 +13,7 @@ import ListToggleButton from "../ListToggleButton";
 import MaterialIcon from "../MaterialIcon";
 import QueryHighlighter from "../QueryHighlighter";
 import { DetailSkeleton, FoundInItemSkeleton } from "../LoadingSkeleton";
-import { appendParams, dateString, hasAccessAndUse, noteText } from "../Helpers";
+import { appendParams, dateString, hasAccessOrUse, noteText } from "../Helpers";
 import { isItemSaved } from "../MyListHelpers";
 import classnames from "classnames";
 import "./styles.scss";
@@ -204,7 +204,7 @@ const RecordsDetail = props => {
             }
         </AccordionItemPanel>
       </AccordionItem>
-      { hasAccessAndUse(props.item.notes) ?
+      { hasAccessOrUse(props.item.notes) ?
         (<AccordionItem className="accordion__item" uuid="accessAndUse">
           <AccordionItemHeading className="accordion__heading" aria-level={2}>
             <AccordionItemButton className="accordion__button">Access and Use</AccordionItemButton>


### PR DESCRIPTION
Renames `hasAccessOrUse` helper and changes its logic to look for notes by type, not title.

fixes #204 