### PR TITLE
Adds heading to digital checkbox in facet modal

### DIFF
--- a/src/components/ModalSearch/index.js
+++ b/src/components/ModalSearch/index.js
@@ -39,7 +39,7 @@ export const FacetModal = props => {
         </button>
       </div>
       <div className="modal-body">
-        <Facet>
+        <Facet title="View Online">
           <CheckBoxInput
             id="online"
             name="true"


### PR DESCRIPTION
Adds a heading to the "online materials" checkbox in the facet modal to improve visibility.

fixes #207