### PR TITLE
Improve setting of back button URL

### DIFF
--- a/src/components/PageDigitalObject/index.js
+++ b/src/components/PageDigitalObject/index.js
@@ -72,15 +72,19 @@ const PageDigitalObject = props => {
     ]
   }
 
-  const itemUrl = () => (
-    document.referrer && document.referrer.includes(props.match.url) && !document.referrer.endsWith("view") ?
+  console.log(document.referrer)
+  console.log(props.match.url)
+  console.log(document.referrer.includes(props.match.url))
+
+  const itemUrl = (
+    document.referrer && document.referrer.includes(`/${props.match.params.type}/${props.match.params.id}`) && !document.referrer.endsWith("/view") ?
       document.referrer : `/${props.match.params.type}/${props.match.params.id}`
-    )
+  )
 
   return (
     <div className="digital">
       <nav>
-        <a href={itemUrl()} className="btn btn--back-item">
+        <a href={itemUrl} className="btn btn--back-item">
           <MaterialIcon icon="keyboard_arrow_left"/>Back to Item Details
         </a>
       </nav>

--- a/src/components/PageDigitalObject/index.js
+++ b/src/components/PageDigitalObject/index.js
@@ -72,10 +72,15 @@ const PageDigitalObject = props => {
     ]
   }
 
+  const itemUrl = () => (
+    document.referrer && document.referrer.includes(props.match.url) && !document.referrer.endsWith("view") ?
+      document.referrer : `/${props.match.params.type}/${props.match.params.id}`
+    )
+
   return (
     <div className="digital">
       <nav>
-        <a href={document.referrer} className="btn btn--back-item">
+        <a href={itemUrl()} className="btn btn--back-item">
           <MaterialIcon icon="keyboard_arrow_left"/>Back to Item Details
         </a>
       </nav>

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -114,7 +114,7 @@ class RecordsChild extends Component {
         <p className="child__text text--truncate">
           <QueryHighlighter query={params.query} text={item.description} />
         </p>
-        {item.hit_count ? (<HitCountBadge className="hit-count--records" hitCount={item.hit_count} />) : null}
+        {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records" hitCount={item.hit_count} />) : null}
       </div>) :
       (<AccordionItem
         preExpanded={preExpanded}
@@ -138,7 +138,7 @@ class RecordsChild extends Component {
             <p className="child__text text--truncate">
               <QueryHighlighter query={params.query} text={item.description} />
             </p>
-            {item.hit_count ? (<HitCountBadge className="hit-count--records-" hitCount={item.hit_count} />) : null}
+            {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records-" hitCount={item.hit_count} />) : null}
             <MaterialIcon icon="expand_more" />
           </AccordionItemButton>
         </AccordionItemHeading>

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -136,10 +136,14 @@ const RecordsDetail = props => {
     setIsSaved(saved)
   }, [props.isItemLoading, props.item, props.myListCount])
 
+  const searchUrl = (
+    props.params && props.params.query ? appendParams("/search", props.params) : "/"
+  )
+
   return (
   <div className={classnames("records__detail", {"hidden": props.isContentShown})}>
     <nav>
-      <a href={appendParams("/search", props.params)} className="btn btn--back">
+      <a href={searchUrl} className="btn btn--back">
         <MaterialIcon icon="keyboard_arrow_left"/>Back to Search
       </a>
     </nav>


### PR DESCRIPTION
Thinking about the back button on digital object pages, I realized there were a number of cases in which the current implementation would not work:
1. Users getting to that page via a link from another site
2. Users typing that URL directly into the browser
3. Users getting to that page from the MyList page

I've added a function which *should* account for all of those cases.

I've also added some logic to hide hit count badges if there is no query.