### PR TITLE
Add visual means to indicate links

### DIFF
--- a/src/styles/components/_modal-base.scss
+++ b/src/styles/components/_modal-base.scss
@@ -84,6 +84,9 @@
   font-family: $sans-serif-stack;
   float: left;
   max-height: calc(80vh - 52px);
+  & a {
+    text-decoration: underline;
+  }
   @media screen and (min-width: $break-lg) {
     width: 100%
   }

--- a/src/styles/components/_page-not-found.scss
+++ b/src/styles/components/_page-not-found.scss
@@ -17,4 +17,7 @@
 .not-found__text {
   font-family: $sans-serif-stack;
   font-size: 20px;
+  & a {
+    text-decoration: underline;
+  }
 }

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -70,4 +70,6 @@
   color: inherit;
   font-size: inherit;
   font-weight: normal;
+  text-decoration: underline;
 }
+


### PR DESCRIPTION
Adds underlines to links where color is the only visual means to indicate that the element is a link. This includes in modals (links to RACcess, the fee schedule, and rockarch.org email), the 404 page, and the "Found In" hierarchy in collection details.
 
Fixes #200 