### PR TITLE
Adds handling for PDF download

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 REACT_APP_ARGO_BASEURL=http://10.0.1.90:8010
 REACT_APP_REQUEST_BROKER_BASEURL=http://request-broker.rockarch.org
 REACT_APP_LOCALSTORAGE_KEY=DIMESMyList
+REACT_APP_S3_BASEURL=https://raciif-dev.s3.amazonaws.com

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -164,6 +164,7 @@ const RecordsDetail = props => {
         <a className="btn btn-download--detail"
           href={`${process.env.REACT_APP_S3_BASEURL}/pdfs/${identifier}`}
           target="_blank"
+          title="opens in a new window"
           rel="noopener noreferrer"
           >Download <MaterialIcon icon="get_app" /></a>
         </>

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -163,6 +163,8 @@ const RecordsDetail = props => {
           href={`${props.item.uri}/view`}>View Online <MaterialIcon icon="visibility" /></a>
         <a className="btn btn-download--detail"
           href={`${process.env.REACT_APP_S3_BASEURL}/pdfs/${identifier}`}
+          target="_blank"
+          rel="noopener noreferrer"
           >Download <MaterialIcon icon="get_app" /></a>
         </>
       ) :

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -8,7 +8,6 @@ import {
     AccordionItemButton,
     AccordionItemPanel,
 } from "../Accordion";
-import Button from "../Button";
 import ListToggleButton from "../ListToggleButton";
 import MaterialIcon from "../MaterialIcon";
 import QueryHighlighter from "../QueryHighlighter";
@@ -140,6 +139,10 @@ const RecordsDetail = props => {
     props.params && props.params.query ? appendParams("/search", props.params) : "/"
   )
 
+  const identifier = (
+    props.item.uri && props.item.uri.split("/")[props.item.uri.split("/").length - 1]
+  )
+
   return (
   <div className={classnames("records__detail", {"hidden": props.isContentShown})}>
     <nav>
@@ -158,12 +161,9 @@ const RecordsDetail = props => {
           toggleSaved={props.toggleInList} />
         <a className="btn btn-launch--detail"
           href={`${props.item.uri}/view`}>View Online <MaterialIcon icon="visibility" /></a>
-        <Button
-          className="btn-download--detail"
-          handleClick={() => alert(`Downloading file for ${props.item.uri}`)}
-          iconAfter="get_app"
-          label="Download"
-          uri={props.item.uri} />
+        <a className="btn btn-download--detail"
+          href={`${process.env.REACT_APP_S3_BASEURL}/pdfs/${identifier}`}
+          >Download <MaterialIcon icon="get_app" /></a>
         </>
       ) :
       (<ListToggleButton


### PR DESCRIPTION
Adds handling for PDF download. Although the link has a `download` attribute, the PDF will always open in a new tab. This is because the PDF is hosted on a different domain, and cross-origin downloading is disabled on all modern browsers.

Also adds a new environment variable for this download location.

fixes #170 