### PR TITLE
Handles unavailability of request broker

### DIFF
--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -61,6 +61,10 @@
 
     /* Requests CSV data and downloads a local file */
     downloadCsv = () => {
+      if (!this.state.isRequestingAvailable) {
+        this.toggleModal("requestingUnavailable");
+        return;
+      }
       this.setState({ isDownloading: true })
       axios
         .post(
@@ -220,11 +224,11 @@
     * to original state
     */
     toggleModal = modal  => {
-      if (["duplication", "readingRoom"].includes(modal) && !this.state.isRequestingAvailable) {
+      if ((["duplication", "email", "readingRoom"].includes(modal)) && !this.state.isRequestingAvailable) {
         this.toggleModal("requestingUnavailable");
-      } else {
-        this.setState({ [modal]: {...this.state[modal], isOpen: !this.state[modal]["isOpen"], error: ""} })
+        return;
       }
+      this.setState({ [modal]: {...this.state[modal], isOpen: !this.state[modal]["isOpen"], error: ""} })
       if (this.state[modal].isOpen) {
         this.toggleList(false)
       }

--- a/src/components/PageMyList/index.js
+++ b/src/components/PageMyList/index.js
@@ -22,8 +22,10 @@
         submitList: [],
         isDownloading: false,
         isLoading: true,
+        isRequestingAvailable: false,
         email: {isOpen: false},
         readingRoom: {isOpen: false},
+        requestingUnavailable: {isOpen: false},
         duplication: {isOpen: false},
         confirm: {
           isOpen: false,
@@ -36,6 +38,10 @@
 
     componentDidMount() {
       this.fetchList()
+      axios
+        .get(`${process.env.REACT_APP_REQUEST_BROKER_BASEURL}/admin`)
+        .then(res => this.setState({ isRequestingAvailable: true }))
+        .catch(err => console.log(err))
     }
 
     /** Returns a list of ArchivesSpace URIs for checked items in list */
@@ -214,7 +220,11 @@
     * to original state
     */
     toggleModal = modal  => {
-      this.setState({ [modal]: {...this.state[modal], isOpen: !this.state[modal]["isOpen"], error: ""} })
+      if (["duplication", "readingRoom"].includes(modal) && !this.state.isRequestingAvailable) {
+        this.toggleModal("requestingUnavailable");
+      } else {
+        this.setState({ [modal]: {...this.state[modal], isOpen: !this.state[modal]["isOpen"], error: ""} })
+      }
       if (this.state[modal].isOpen) {
         this.toggleList(false)
       }
@@ -287,6 +297,12 @@
             submitList={this.state.submitList}
             toggleList={this.toggleList}
             toggleModal={() => this.toggleModal("duplication")}
+          />
+          <ModalConfirm
+            {...this.state.requestingUnavailable}
+            message="Sorry, our system is unable to process requests right now. We're working to fix this! Please try again later."
+            title="Can't Complete Request"
+            toggleModal={() => this.toggleModal("requestingUnavailable")}
           />
           <ModalConfirm
             {...this.state.confirm}


### PR DESCRIPTION
When MyList page is loaded, pings Request Broker to see if it is available. If the request returns an error code, sets a flag which loads a smaller modal indicating that requesting is out of order. 

I've added RockefellerArchiveCenter/request_broker#70 to implement a more meaningful ping endpoint in that system.

Fixes #243 