### PR TITLE
Improve responsiveness, particularly on smaller screens

### DIFF
--- a/src/components/ModalConfirm/index.js
+++ b/src/components/ModalConfirm/index.js
@@ -18,7 +18,7 @@ const ModalConfirm = props => (
         <MaterialIcon icon="close"/>
       </button>
     </div>
-    <div className="modal-body">
+    <div className="modal-body--confirm">
       <div className="modal-message">
         {props.message}
       </div>

--- a/src/components/ModalSearch/index.js
+++ b/src/components/ModalSearch/index.js
@@ -37,7 +37,7 @@ export const FacetModal = props => {
           <MaterialIcon icon="close"/>
         </button>
       </div>
-      <div className="modal-body">
+      <div className="modal-body--search">
         <Facet title="View Online">
           <CheckBoxInput
             id="online"

--- a/src/components/MyListExportActions/index.js
+++ b/src/components/MyListExportActions/index.js
@@ -5,7 +5,7 @@ import classnames from "classnames";
 
 
 const MyListExportActions = ({ confirmDeleteAll, downloadCsv, emailList, isDownloading }) => (
-  <div className="mylist__export-actions show-on-lg-up">
+  <div className="mylist__export-actions">
     <Button
       className="btn--orange btn--sm"
       label="Email List"

--- a/src/components/MyListSidebar/index.js
+++ b/src/components/MyListSidebar/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import Button from "../Button";
 
 const MyListSidebar = ({ duplicationRequest, readingRoomRequest, sendEmail }) => (
-  <aside className="mylist__sidebar show-on-lg-up">
+  <aside className="mylist__sidebar">
     <Button
       className="btn--orange btn--lg"
       label="Schedule a Visit"

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -20,7 +20,7 @@ NavItem.propTypes = {
 
 export const Nav = ({ ariaLabel, children, className}) => (
   <nav className={classnames("nav", className)} aria-label={ariaLabel}>
-    <ul className="nav__list show-on-lg-up">
+    <ul className="nav__list">
       {children}
     </ul>
     <NavDropdown />

--- a/src/styles/base/_grid.scss
+++ b/src/styles/base/_grid.scss
@@ -10,8 +10,8 @@ $grid-column: (
 ); //does this work??
 
 .container--full-width {
-  @include grid-container;
   width: 100%;
+  @include grid-container;
 }
 
 .container {

--- a/src/styles/base/_layout.scss
+++ b/src/styles/base/_layout.scss
@@ -26,10 +26,10 @@ form {
   list-style: none;
   background-color: $off-white;
   ol {
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       @include grid-column(12);
     }
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       @include grid-column(8);
       @include grid-push(2);
       padding-left: $gutters-default;
@@ -59,10 +59,10 @@ form {
 
 .three-column-content {
   @include grid-column(12);
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     @include grid-column(9);
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(7);
     padding-bottom: 100px;
     box-sizing: border-box;
@@ -73,20 +73,20 @@ form {
 
 .left-sidebar {
   @include grid-column(6);
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     @include grid-column(3);
     height: 100%;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(2);
   }
 }
 .right-sidebar {
   @include grid-column(12);
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     @include grid-column(9);
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(3);
     box-sizing: border-box;
     padding-right: 44px;
@@ -98,7 +98,7 @@ form {
 .one-column-content {
   @include grid-column(12);
   padding-bottom: 100px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(8);
     @include grid-shift(2);
   }
@@ -106,7 +106,7 @@ form {
 
 .rac-call-to-action {
   padding-top: 60px;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     margin-right: 30px;
   }
   .action-button {
@@ -118,7 +118,7 @@ form {
     background-size: cover;
     margin-bottom: $gutters-default;
     margin-right: $gutters-default * 2;
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       @include grid-column(6);
       margin-right: 0;
       padding: 27px 64px 40px 25px;
@@ -134,18 +134,18 @@ form {
       color: $deep-navy;
       margin-bottom: 6px;
       border-bottom: none;
-      @media screen and (min-width: $break-md) {
+      @include md-up {
         font-size: 24px;
         line-height: 28px;
       }
-      @media screen and (min-width: $break-lg) {
+      @include lg-up {
         font-size: 30px;
         line-height: 36px;
         max-width: 400px;
       }
     }
     p {
-      @media screen and (min-width: $break-lg) {
+      @include lg-up {
         max-width: 400px;
       }
     }
@@ -156,19 +156,19 @@ form {
 
 .rac-roles {
   .roles {
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       @include grid-column(9);
     }
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       @include grid-column(8);
     }
   }
   .role {
     margin-bottom: 25px;
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       margin-bottom: 32px;
     }
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       @include grid-column(6);
       padding: 0 40px;
       box-sizing: border-box;
@@ -179,12 +179,12 @@ form {
     height: 60px;
     width: 60px;
     margin-bottom: 12px;
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       height: 74px;
       width: 74px;
       margin-bottom: 18px;
     }
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       height: 92px;
       width: 92px;
     }
@@ -207,15 +207,15 @@ form {
 
 .rac-quicklinks {
   .links {
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       @include grid-column(9);
     }
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       @include grid-column(8);
     }
   }
   .link-column {
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       @include grid-column(6);
       padding: 0 40px;
       box-sizing: border-box;
@@ -253,7 +253,7 @@ form {
   justify-content: center;
   .instagram-posts {
     margin: -20px;
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       margin: 0;
     }
   }
@@ -265,7 +265,7 @@ form {
     text-transform: uppercase;
     color: $pure-white;
     float: right;
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       margin-right: 20px;
     }
     &:hover {
@@ -285,11 +285,11 @@ form {
 //   padding-bottom: 60px;
 //   display: flex;
 //   flex-wrap: wrap;
-//   @media screen and (min-width: $break-md) {
+//   @include md-up {
 //     padding-top: 30px;
 //     padding-bottom: 80px;
 //   }
-//   @media screen and (min-width: $break-lg) {
+//   @include lg-up {
 //     padding-top: 40px;
 //     padding-bottom: 100px;
 //   }
@@ -301,7 +301,7 @@ form {
 //   .title {
 //     margin-top: 20px;
 //     margin-bottom: 30px;
-//     @media screen and (min-width: $break-md) {
+//     @include md-up {
 //       @include grid-column(3);
 //       margin-top: 0px;
 //     }
@@ -332,10 +332,10 @@ form {
   &:hover {
     text-decoration: none;
   }
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     @include grid-column(6);
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(6);
   }
   .text {
@@ -347,7 +347,7 @@ form {
     line-height: 22px;
     padding: 18px 20px;
     box-sizing: border-box;
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       padding: 20px 30px;
       max-width: 300px;
       font-size: 20px;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -30,10 +30,10 @@ h1 {
   font-weight: $font-weight-bold;
   font-size: 32px;
   color: $dark-gray;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     font-size: 42px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     font-size: 52px;
   }
 }
@@ -51,7 +51,7 @@ h2 {
   // padding-bottom: 12px; // NOTE: style conflicting with Mirador
   margin-bottom: 20px;
   margin-top: 60px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin-top: 0px;
     font-size: 28px;
   }
@@ -61,7 +61,7 @@ h3 {
   font-size: 18px;
   margin-top: 30px;
   margin-bottom: 10px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     font-size: 20px;
   }
 }
@@ -69,7 +69,7 @@ h3 {
 h4 {
   font-size: 14px;
   color: $faded-orange;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     font-size: 16px;
   }
 }
@@ -92,7 +92,7 @@ a {
 ul {
   font-family: inherit;
   line-height: 23px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     font-size: 17px;
     line-height: 24px;
   }
@@ -103,7 +103,7 @@ small {
   font-size: 14px;
   line-height: 20px;
   margin-bottom: 12px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     font-size: 15px;
     line-height: 21px;
   }
@@ -170,7 +170,7 @@ small {
   &:hover {
     color: $off-white;
   }
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     line-height: 18px;
     font-size: 15px;
   }
@@ -191,10 +191,10 @@ small {
   &:hover {
     color: $off-white;
   }
-  @media screen and (min-width: $break-md)  {
+  @include md-up  {
     line-height: 70px;
   }
-  @media screen and (min-width: $break-lg)  {
+  @include lg-up  {
     line-height: 60px;
   }
 }
@@ -241,7 +241,7 @@ small {
   font-family: $sans-serif-stack;
   font-size: 24px;
   color: $deep-navy;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     font-size: 28px;
   }
 }
@@ -289,11 +289,11 @@ small {
   font-size: 18px;
   line-height: 24px;
   color: $dark-gray;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     font-size: 28px;
     line-height: 38px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     font-size: 34px;
     line-height: 42px;
   }
@@ -302,7 +302,7 @@ small {
 .mylist__title {
   @include page-title;
   float: left;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     float: none;
   }
 }

--- a/src/styles/base/_utilities.scss
+++ b/src/styles/base/_utilities.scss
@@ -27,30 +27,38 @@ $transition-default: all 0.2s ease;
   display: flex;
 }
 
-.show-on-md-up {
+
+@mixin md-up {
+  @media screen and (min-width: $break-md) { @content; }
+}
+@mixin lg-up {
+  @media screen and (min-width: $break-lg) { @content; }
+}
+
+@mixin show-on-md-up {
   display: none;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     display: inherit;
   }
 }
 
-.hide-on-md-up {
-  display: block;
-  @media screen and (min-width: $break-md) {
+@mixin hide-on-md-up {
+  display: inherit;
+  @include md-up {
     display: none
   }
 }
 
-.show-on-lg-up {
+@mixin show-on-lg-up {
   display: none;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     display: inherit;
   }
 }
 
 .hide-on-lg-up {
-  display: block;
-  @media screen and (min-width: $break-lg) {
+  display: inherit;
+  @include lg-up {
     display: none;
   }
 }

--- a/src/styles/components/_agent-attribute.scss
+++ b/src/styles/components/_agent-attribute.scss
@@ -10,10 +10,10 @@
 .agent-attribute {
   @include grid-column(12);
   margin-bottom: 24px;
-  @media screen and (min-width: $break-md)  {
+  @include md-up  {
     @include grid-column(4);
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(3);
     margin-bottom: 27px;
   }

--- a/src/styles/components/_biographies.scss
+++ b/src/styles/components/_biographies.scss
@@ -7,10 +7,10 @@
   .biography {
     margin-bottom: 26px;
     @include grid-column(6);
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       @include grid-column(4);
     }
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       @include grid-column(3)
     }
     img {
@@ -33,7 +33,7 @@
 }
 
 .bio-page-image {
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     float: left;
     margin-right: 20px;
   }

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -143,7 +143,7 @@
   @extend .btn--gray;
   @extend .btn--sm;
   margin-top: 20px;
-  @media screen and (min-width: $break-md)  {
+  @include md-up  {
     margin-top: 30px;
   }
 }
@@ -232,7 +232,7 @@
 .btn-add--content {
   @include records-btn;
   @extend .btn--orange;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     position: relative;
   }
 }
@@ -250,7 +250,7 @@
   font-size: 10px;
   margin-bottom: 10px;
   text-align: center;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     width: unset;
   }
 }
@@ -263,7 +263,7 @@
   @include records-detail-btn;
   @extend .btn--orange;
   box-sizing: border-box;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     margin-right: 10px;
   }
 }

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -208,6 +208,7 @@
   font-size: 14px;
   text-transform: none;
   letter-spacing: unset;
+  margin-right: 16px;
   & .material-icons {
     @include icon-margin-right;
     font-size: 18px;

--- a/src/styles/components/_captcha.scss
+++ b/src/styles/components/_captcha.scss
@@ -6,10 +6,10 @@
   & div > div > div {
     position: relative;
     transform-origin: left center;
-    @media screen and (min-width: $break-lg) and (max-width: 1350px) {
-      left: 50%;
-      transform: scale(0.87) translateX(-50%);
-      transform-origin: left center;
+    transform: scale(0.90);
+    @media screen and (min-width: 1240px) {
+      transform: scale(1);
     }
   }
 }
+

--- a/src/styles/components/_captcha.scss
+++ b/src/styles/components/_captcha.scss
@@ -1,18 +1,15 @@
-// Hacky hacks because the Google ReCAPTCHA has a set width
+@import "../base/utilities";
+
 .captcha {
   margin: 10px 0px;
   max-width: 250px;
-  @media screen and (min-width: 414px) {
-    max-width: none;
-  }
   & div > div > div {
     position: relative;
-    left: 50%;
-    transform: scale(0.8) translateX(-50%);
     transform-origin: left center;
-    @media screen and (min-width: 414px) {
-      transform: none;
-      left: 0;
+    @media screen and (min-width: $break-lg) and (max-width: 1350px) {
+      left: 50%;
+      transform: scale(0.87) translateX(-50%);
+      transform-origin: left center;
     }
   }
 }

--- a/src/styles/components/_context-switcher.scss
+++ b/src/styles/components/_context-switcher.scss
@@ -7,7 +7,7 @@
   position: fixed;
   bottom: 0;
   left: 0;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     display: none;
   }
 }
@@ -20,7 +20,7 @@
   width: 100%;
   position: fixed;
   bottom: 0;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     position: relative;
     width: 50%;
   }
@@ -28,7 +28,7 @@
 
 .toggle-context--active {
   opacity: 0;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     opacity: 1;
     background: $off-white;
     color: $dark-gray;

--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -53,7 +53,7 @@
   margin-bottom: 30px;
   display: block;
   float: right;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     display: none;
   }
 }

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -31,12 +31,12 @@
   @include grid-column(12);
   margin-bottom: 40px;
   margin-left: 0px;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     @include grid-column(6);
     margin-left: 0px;
     margin-bottom: 50px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(3);
     margin-left: 0px;
     margin-bottom: 50px;
@@ -59,11 +59,11 @@
       }
     }
   }
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     @include grid-column(12);
     margin-left: 0px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(3);
     float: right;
     text-align: right;
@@ -78,5 +78,5 @@
 .footer-secondary__data {
   @include grid-column(12);
   width: 100%;
-  @media screen and (min-width: $break-lg) {text-align: right;}
+  @include lg-up {text-align: right;}
 }

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -14,10 +14,10 @@
   position: fixed;
   top: 0;
   z-index: 999;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     height: 70px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     height: 60px;
   }
 }
@@ -28,10 +28,10 @@
   z-index: 3;
   @include grid-column(11);
   box-sizing: border-box;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     margin-top:16px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(7);
     margin-top:21px;
     padding-left: 50px;
@@ -45,10 +45,10 @@
 .header-secondary__title {
   @include secondary-header-title;
   margin: 0;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     margin-right: 10px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
       float: left;
     }
 }
@@ -56,7 +56,7 @@
 .header-secondary__subtitle {
   @include secondary-header-subtitle;
   margin: 0;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     float: left;
     margin-top: 4px;
   }

--- a/src/styles/components/_hero.scss
+++ b/src/styles/components/_hero.scss
@@ -7,12 +7,12 @@
   margin-top: 10px;
   padding: 30px;
   box-sizing: border-box;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     margin-top: 113px;
     justify-content: center;
     flex-wrap: nowrap;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin-top: 103px;
   }
 }
@@ -22,10 +22,10 @@
   text-align: left;
   img {
     width: 85px;
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       width: 120px;
     }
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       width: 160px;
     }
   }
@@ -34,11 +34,11 @@
 .hero__text {
   text-align: left;
   width: 100%;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     width: unset;
     margin-left: 30px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin-left: 50px;
   }
 }

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -143,7 +143,7 @@ label {
   padding: 20px;
   position: absolute;
   z-index: 999;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     right: 20px;
   }
 }

--- a/src/styles/components/_modal-base.scss
+++ b/src/styles/components/_modal-base.scss
@@ -83,11 +83,13 @@
 .modal-body {
   font-family: $sans-serif-stack;
   float: left;
-  max-height: calc(80vh - 52px);
+  min-height: calc(80vh - 52px);
   & a {
     text-decoration: underline;
   }
   @include lg-up {
-    width: 100%
+    width: 100%;
+    display: flex;
+    align-items: stretch;
   }
 }

--- a/src/styles/components/_modal-base.scss
+++ b/src/styles/components/_modal-base.scss
@@ -87,7 +87,7 @@
   & a {
     text-decoration: underline;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     width: 100%
   }
 }

--- a/src/styles/components/_modal-confirm.scss
+++ b/src/styles/components/_modal-confirm.scss
@@ -9,7 +9,7 @@
   border-radius: 3px;
   overflow: auto;
   outline: none;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     top: $confirm-modal-content-margin-lg;
     left: $confirm-modal-content-margin-lg;
     right: $confirm-modal-content-margin-lg;

--- a/src/styles/components/_modal-mylist.scss
+++ b/src/styles/components/_modal-mylist.scss
@@ -4,7 +4,7 @@
   padding: 30px 20px;
   box-sizing: border-box;
   @include lg-up {
-    @include grid-column(8);
+    width: 66%
   }
 }
 
@@ -19,7 +19,7 @@
   font-size: 14px;
   padding-bottom: 18px;
   @include lg-up {
-    @include grid-column(4);
+    width: 34%;
     float: right;
   }
 }

--- a/src/styles/components/_modal-mylist.scss
+++ b/src/styles/components/_modal-mylist.scss
@@ -90,8 +90,11 @@
 
 .modal-form__buttons {
   float: left;
-  margin: 20px 0;
+  margin: 10px 0;
   width: 100%;
+  & > .btn {
+    margin-top: 10px;
+  }
 }
 
 .modal-form__error {

--- a/src/styles/components/_modal-mylist.scss
+++ b/src/styles/components/_modal-mylist.scss
@@ -3,7 +3,7 @@
   float: left;
   padding: 30px 20px;
   box-sizing: border-box;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(8);
   }
 }
@@ -18,7 +18,7 @@
   box-sizing: border-box;
   font-size: 14px;
   padding-bottom: 18px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(4);
     float: right;
   }

--- a/src/styles/components/_modal-saved-item.scss
+++ b/src/styles/components/_modal-saved-item.scss
@@ -34,7 +34,7 @@
 
 .modal-saved-item__item-description  {
   @include grid-column(11);
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(9);
   }
 }

--- a/src/styles/components/_modal-search.scss
+++ b/src/styles/components/_modal-search.scss
@@ -3,23 +3,11 @@
   top: 0;
   left: 0;
   right: unset;
-  width: 420px;
+  max-width: 420px;
   height: 100vh;
   border-radius: 0px;
   border: 1px solid $dark-gray;
   background: $pale-blue;
-}
-
-.modal-content--hits {
-  @extend .modal-content;
-  left: unset;
-  top: 0;
-  right: 0;
-  width: 420px;
-  height: 100vh;
-  border-radius: 0px;
-  border: 1px solid $dark-gray;
-  background: $pure-white;
 }
 
 .modal-header--search {

--- a/src/styles/components/_my-list.scss
+++ b/src/styles/components/_my-list.scss
@@ -10,7 +10,6 @@
 
 .mylist__header {
   @include grid-column(12);
-  margin-top: 80px;
 }
 
 .mylist__export-actions {

--- a/src/styles/components/_my-list.scss
+++ b/src/styles/components/_my-list.scss
@@ -2,7 +2,7 @@
 
 .mylist main {
   @include grid-column(12);
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(8);
   }
 }
@@ -13,6 +13,7 @@
 }
 
 .mylist__export-actions {
+  @include show-on-lg-up;
   padding-bottom: 30px;
 }
 
@@ -29,6 +30,7 @@
   & > button {
     align-self: flex-start;
   }
+  @include show-on-lg-up;
 }
 
 .mylist__title {

--- a/src/styles/components/_my-list.scss
+++ b/src/styles/components/_my-list.scss
@@ -3,7 +3,8 @@
 .mylist main {
   @include grid-column(12);
   @include lg-up {
-    @include grid-column(8);
+    width: 66%;
+    box-sizing: border-box;
   }
 }
 
@@ -18,11 +19,10 @@
 }
 
 .mylist__sidebar {
-  @include grid-column(4);
+  width: 34%;
   background: $off-white;
   float: right;
-  margin-left: 45px;
-  margin-right: -45px;
+  margin-right: -30px;
   padding: 60px 0px 60px 40px;
   box-sizing: border-box;
   display: flex;

--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -8,7 +8,7 @@
   margin-left: 0;
   height: 60px;
   box-sizing: border-box;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(5);
     border: none;
     float: right;
@@ -16,10 +16,11 @@
 }
 
 .nav__list {
+  @include show-on-lg-up;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin-right: -15px;
   }
 }
@@ -31,7 +32,7 @@
     background-color: $deep-blue;
     transition: $transition-default
   }
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     padding-left: 14px;
     padding-right: 14px;
   }

--- a/src/styles/components/_page-search.scss
+++ b/src/styles/components/_page-search.scss
@@ -75,7 +75,7 @@
   position: relative;
   display: inline-block;
   box-sizing: border-box;
-  margin-left: 16px;
+  margin-top: 16px;
 }
 
 .select__sort__control > .material-icons {

--- a/src/styles/components/_page-search.scss
+++ b/src/styles/components/_page-search.scss
@@ -5,10 +5,10 @@
   display: flex;
   flex-wrap: wrap;
   width: 100%;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     align-items: flex-end;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     flex-wrap: nowrap;
     align-items: flex-end;
   }
@@ -16,18 +16,18 @@
 
 .results__footer {
   margin-bottom: 30px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     justify-content: flex-end;
   }
 }
 
 .results__summary {
   width: 100%;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     width: 50%;
     order: 0;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     width: unset;
     order: 1;
     text-align: right;
@@ -37,17 +37,17 @@
 .results__summary--text {
   font-family: inherit;
   min-width: 225px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin-bottom: 0;
   }
 }
 
 .results__controls {
   width: 100%;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     order: 2
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     width: unset;
     order: 0;
     flex-grow: 1;
@@ -56,14 +56,14 @@
 
 .results__pagination {
   width: 100%;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     width: 50%;
     order: 1;
     margin-bottom: 10px;
     text-align: right;
     align-self: flex-end;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     width: unset;
     order: 2;
     margin-left: 10px;

--- a/src/styles/components/_pagination.scss
+++ b/src/styles/components/_pagination.scss
@@ -5,7 +5,7 @@
   font-family: $sans-serif-stack;
   list-style: none;
   padding-left: 0;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     margin-bottom: 0;
   }
 }
@@ -42,7 +42,7 @@
     line-height: normal;
     margin: 0;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     padding: 0px 7px;
   }
 }

--- a/src/styles/components/_records-content.scss
+++ b/src/styles/components/_records-content.scss
@@ -7,7 +7,7 @@
   float: left;
   padding: 40px 30px;
   box-sizing: border-box;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     width: 60%;
   }
 }
@@ -177,7 +177,7 @@
 .child__description {
   min-width: 0;
   order: 1;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     order: unset;
     flex-basis: 50%;
     flex-grow: 2;
@@ -190,7 +190,7 @@
   align-items: flex-start;
   flex-shrink: 0;
   order: 3;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     width: unset;
     order: unset;
     justify-content: flex-end;
@@ -231,7 +231,7 @@
 .child__text {
   font-size: 14px;
   order: 2;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     order: unset
   }
 }

--- a/src/styles/components/_records-content.scss
+++ b/src/styles/components/_records-content.scss
@@ -10,6 +10,9 @@
   @include lg-up {
     width: 60%;
   }
+  &.hidden {
+    @include show-on-lg-up;
+  }
 }
 
 .content__title {

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -12,14 +12,14 @@
   font-family: $sans-serif-stack;
   &.hidden {
     display: none;
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       display: unset;
     }
   }
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     padding: 0px 40px 50px 40px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     width: 40%;
     max-height: 100vh;
     position: sticky;

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -11,10 +11,7 @@
   float: left;
   font-family: $sans-serif-stack;
   &.hidden {
-    display: none;
-    @include lg-up {
-      display: unset;
-    }
+    @include show-on-lg-up;
   }
   @include md-up {
     padding: 0px 40px 50px 40px;

--- a/src/styles/components/_saved-item.scss
+++ b/src/styles/components/_saved-item.scss
@@ -33,7 +33,7 @@
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     flex-wrap: nowrap;
   }
 }
@@ -44,7 +44,7 @@
   flex-wrap: nowrap;
   align-items: flex-start;
   width: 100%;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     width: unset;
   }
 }

--- a/src/styles/components/_search-form.scss
+++ b/src/styles/components/_search-form.scss
@@ -11,10 +11,10 @@ input[type=search] {
   display: flex;
   justify-content: center;
   margin: 30px 30px 110px 30px;
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     margin: 59px 75px 190px 75px;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin: 64px 0 233px 0;
   }
 }
@@ -27,7 +27,7 @@ input[type=search] {
 
 .results, .search-form--results {
   margin: 0px 30px;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin: 0px 80px;
   }
 }
@@ -42,7 +42,7 @@ input[type=search] {
 
 .input__search {
   width:100%;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     width: calc(100% - 220px);
   }
 }
@@ -69,7 +69,7 @@ input[type=search] {
     right: 23px;
     top: 20px;
   }
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     display: block;
   }
 }

--- a/src/styles/components/_side-nav.scss
+++ b/src/styles/components/_side-nav.scss
@@ -2,7 +2,7 @@
 // TODO: factor out typography
 
 .rac-side-nav {
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     display: flex;
     position: sticky;
     top: 60px;
@@ -15,12 +15,12 @@
     background: $burnt-orange;
     position: absolute;
     width: calc(50% - 60px);
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       display: block;
       position: unset;
       width:100%;
     }
-    @media screen and (min-width: $break-lg) {
+    @include lg-up {
       padding: 36px 25px 36px 25px;
       a {
         font-size: 14px;
@@ -53,7 +53,7 @@
     margin-left: 0;
     margin-bottom: 28px;
     margin-top: -52px;
-    @media screen and (min-width: $break-md) {
+    @include md-up {
       display: none;
     }
   }

--- a/src/styles/components/_social-icons.scss
+++ b/src/styles/components/_social-icons.scss
@@ -1,7 +1,7 @@
 @import "../styles";
 
 .rac-social-icons {
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     display: flex;
     justify-content: space-evenly;
   }

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -31,7 +31,7 @@
     box-shadow: 0 0 8px 0 $light-gray;
     transition: $transition-default;
   }
-  @media screen and (min-width: $break-md) {
+  @include md-up {
     @include grid-column(4);
     padding: 32px 20px;
     min-height: 210px;
@@ -39,7 +39,7 @@
       padding: 31px 19px;
     }
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     @include grid-column(3)
     padding: 32px 26px;
     min-height: 220px;
@@ -67,7 +67,7 @@
     left: 0;
     right: 0;
   }
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin-top: 10px !important;
   }
 }
@@ -76,7 +76,7 @@
   @include tile-date-text;
   margin-top: 8px;
   order: 3;
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     margin-top: 10px;
   }
 }


### PR DESCRIPTION
Improves responsiveness of various pages and components:
- fix stacking and indent of filter and sort by components on search page for small screens
- add max-width to facet modal to fix text overflow
- apply `.hidden` styles to records content on small screens so so components aren't visible in footer.
- prevent reading room request button from wrapping in MyList sidebar
- Improve button stacking in MyList modals
- improve captcha sizing breakpoints
- Ensure form background always goes to bottom of MyList modals
- remove top padding from MyList header
- adds media query mixins and replace existing media queries

fixes #244 