### PR TITLE
Only highlight queries on components with hit counts

### DIFF
--- a/src/components/QueryHighlighter/index.js
+++ b/src/components/QueryHighlighter/index.js
@@ -4,8 +4,8 @@ import Highlighter from "react-highlight-words";
 import "./styles.scss";
 
 
-const QueryHighlighter = ({ hitCount, query, text }) => {
-  const parsedQuery = query && hitCount ? query.replace(/"([^"]+(?="))"/g, '$1').split(" ") : []
+const QueryHighlighter = ({ query, text }) => {
+  const parsedQuery = query ? query.replace(/"([^"]+(?="))"/g, '$1').split(" ") : []
   return (
     <Highlighter
         highlightClassName="query-highlight"

--- a/src/components/QueryHighlighter/index.js
+++ b/src/components/QueryHighlighter/index.js
@@ -4,8 +4,8 @@ import Highlighter from "react-highlight-words";
 import "./styles.scss";
 
 
-const QueryHighlighter = ({ query, text}) => {
-  const parsedQuery = query ? query.replace(/"([^"]+(?="))"/g, '$1').split(" ") : []
+const QueryHighlighter = ({ hitCount, query, text }) => {
+  const parsedQuery = query && hitCount ? query.replace(/"([^"]+(?="))"/g, '$1').split(" ") : []
   return (
     <Highlighter
         highlightClassName="query-highlight"

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -93,7 +93,7 @@ class RecordsChild extends Component {
           <button id={`accordion__heading-${item.uri}`}
                   className={classnames("child__title", `child__title--${item.type}`)}
                   onClick={() => this.handleItemClick(item.uri)}>
-            <QueryHighlighter query={params.query} text={item.title} />
+            <QueryHighlighter query={item.hit_count ? params.query : null} text={item.title} />
           </button>
           {item.dates === item.title ? (null) : (<p className="child__text">{item.dates}</p>)}
         </div>
@@ -112,7 +112,7 @@ class RecordsChild extends Component {
             toggleSaved={this.toggleSaved} />
         </div>
         <p className="child__text text--truncate">
-          <QueryHighlighter query={params.query} text={item.description} />
+          <QueryHighlighter query={item.hit_count ? params.query : null} text={item.description} />
         </p>
         {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records" hitCount={item.hit_count} />) : null}
       </div>) :
@@ -133,10 +133,10 @@ class RecordsChild extends Component {
           <AccordionItemButton
               className={`child__title child__title--${item.type}`}
               onClick={() => this.handleCollectionClick(item.uri)} >
-            <QueryHighlighter query={params.query} text={item.title} />
+            <QueryHighlighter query={item.hit_count ? params.query : null} text={item.title} />
             {item.title === item.dates ? (null) : (<p className="child__text">{item.dates}</p>)}
             <p className="child__text text--truncate">
-              <QueryHighlighter query={params.query} text={item.description} />
+              <QueryHighlighter query={item.hit_count ? params.query : null} text={item.description} />
             </p>
             {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records-" hitCount={item.hit_count} />) : null}
             <MaterialIcon icon="expand_more" />

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -93,7 +93,7 @@ class RecordsChild extends Component {
           <button id={`accordion__heading-${item.uri}`}
                   className={classnames("child__title", `child__title--${item.type}`)}
                   onClick={() => this.handleItemClick(item.uri)}>
-            <QueryHighlighter query={item.hit_count ? params.query : null} text={item.title} />
+            <QueryHighlighter hitCount={item.hit_count} query={params.query} text={item.title} />
           </button>
           {item.dates === item.title ? (null) : (<p className="child__text">{item.dates}</p>)}
         </div>
@@ -112,7 +112,7 @@ class RecordsChild extends Component {
             toggleSaved={this.toggleSaved} />
         </div>
         <p className="child__text text--truncate">
-          <QueryHighlighter query={item.hit_count ? params.query : null} text={item.description} />
+          <QueryHighlighter hitCount={item.hit_count} query={params.query} text={item.description} />
         </p>
         {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records" hitCount={item.hit_count} />) : null}
       </div>) :
@@ -133,10 +133,10 @@ class RecordsChild extends Component {
           <AccordionItemButton
               className={`child__title child__title--${item.type}`}
               onClick={() => this.handleCollectionClick(item.uri)} >
-            <QueryHighlighter query={item.hit_count ? params.query : null} text={item.title} />
+            <QueryHighlighter hitCount={item.hit_count} query={params.query} text={item.title} />
             {item.title === item.dates ? (null) : (<p className="child__text">{item.dates}</p>)}
             <p className="child__text text--truncate">
-              <QueryHighlighter query={item.hit_count ? params.query : null} text={item.description} />
+              <QueryHighlighter hitCount={item.hit_count} query={params.query} text={item.description} />
             </p>
             {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records-" hitCount={item.hit_count} />) : null}
             <MaterialIcon icon="expand_more" />

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -86,6 +86,7 @@ class RecordsChild extends Component {
   render() {
     const { ariaLevel, item, myListCount, params, preExpanded, setActiveRecords, toggleInList } = this.props;
     const firstChildType = this.state.children.length && this.state.children[0].type
+    const query = item.hit_count ? params.query : null
     const isMobile = window.innerWidth < 580;
     return (item.type === "object" ?
       (<div className={classnames("child__list-item", `child__list-item--${item.type}`)} >
@@ -93,7 +94,7 @@ class RecordsChild extends Component {
           <button id={`accordion__heading-${item.uri}`}
                   className={classnames("child__title", `child__title--${item.type}`)}
                   onClick={() => this.handleItemClick(item.uri)}>
-            <QueryHighlighter hitCount={item.hit_count} query={params.query} text={item.title} />
+            <QueryHighlighter query={query} text={item.title} />
           </button>
           {item.dates === item.title ? (null) : (<p className="child__text">{item.dates}</p>)}
         </div>
@@ -112,7 +113,7 @@ class RecordsChild extends Component {
             toggleSaved={this.toggleSaved} />
         </div>
         <p className="child__text text--truncate">
-          <QueryHighlighter hitCount={item.hit_count} query={params.query} text={item.description} />
+          <QueryHighlighter query={query} text={item.description} />
         </p>
         {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records" hitCount={item.hit_count} />) : null}
       </div>) :
@@ -133,10 +134,10 @@ class RecordsChild extends Component {
           <AccordionItemButton
               className={`child__title child__title--${item.type}`}
               onClick={() => this.handleCollectionClick(item.uri)} >
-            <QueryHighlighter hitCount={item.hit_count} query={params.query} text={item.title} />
+            <QueryHighlighter query={query} text={item.title} />
             {item.title === item.dates ? (null) : (<p className="child__text">{item.dates}</p>)}
             <p className="child__text text--truncate">
-              <QueryHighlighter hitCount={item.hit_count} query={params.query} text={item.description} />
+              <QueryHighlighter query={query} text={item.description} />
             </p>
             {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records-" hitCount={item.hit_count} />) : null}
             <MaterialIcon icon="expand_more" />


### PR DESCRIPTION
This is not totally perfect, but it's A LOT better.

Queries will only be highlighted on components that also have a hit count. While this will still result in some spurious query highlighting, it removes the really misleading highlights.

fixes #251 