### PR TITLE
Return text from all matching notes

### DIFF
--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -14,7 +14,7 @@ export const hasAccessOrUse = notes => {
 }
 
 
-/** Returns text for a specific note by type */
+/** Returns text for a specific note (or notes) by type */
 export const noteText = (notes, noteType) => {
   let filteredNotes = notes && notes.filter(n => {return n.type === noteType})
   return filteredNotes ? filteredNotes.map(note => note.subnotes.map(s => s.content)).join("\r") : null

--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -16,8 +16,8 @@ export const hasAccessOrUse = notes => {
 
 /** Returns text for a specific note by type */
 export const noteText = (notes, noteType) => {
-  let note = notes && notes.filter(n => {return n.type === noteType})[0]
-  return note ? note.subnotes.map(s => s.content).join("\r\n") : null
+  let filteredNotes = notes && notes.filter(n => {return n.type === noteType})
+  return filteredNotes ? filteredNotes.map(note => note.subnotes.map(s => s.content)).join("\r") : null
 }
 
 


### PR DESCRIPTION
Instead of just returning the first, returns text from all notes of a type.

fixes #254 