### PR TITLE
Truncates description text

### DIFF
--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -49,3 +49,15 @@ export const formatBytes = (bytes, decimals = 2) => {
 
     return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
+
+/** Trims a string to a specified length */
+export const truncateString = (text, maxLength) => {
+  if (text) {
+    if (text.length < maxLength) {
+      return text
+    }
+    return text.substr(0, text.indexOf(" ", maxLength)) + "...";
+  } else {
+    return null
+  }
+}

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -12,7 +12,7 @@ import { HitCountBadge } from "../HitCount";
 import ListToggleButton from "../ListToggleButton";
 import MaterialIcon from "../MaterialIcon";
 import QueryHighlighter from "../QueryHighlighter";
-import { appendParams, dateString, noteText } from "../Helpers";
+import { appendParams, dateString, noteText, truncateString} from "../Helpers";
 import { isItemSaved } from "../MyListHelpers";
 import classnames from "classnames";
 import "./styles.scss";
@@ -118,7 +118,7 @@ class RecordsChild extends Component {
             toggleSaved={this.toggleSaved} />
         </div>
         <p className="child__text text--truncate">
-          <QueryHighlighter query={query} text={item.description} />
+          <QueryHighlighter query={query} text={truncateString(item.description, 200)} />
         </p>
         {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records" hitCount={item.hit_count} />) : null}
       </div>) :
@@ -142,7 +142,7 @@ class RecordsChild extends Component {
             <QueryHighlighter query={query} text={item.title} />
             {item.title === item.dates ? (null) : (<p className="child__text">{item.dates}</p>)}
             <p className="child__text text--truncate">
-              <QueryHighlighter query={query} text={item.description} />
+              <QueryHighlighter query={query} text={truncateString(item.description, 200)} />
             </p>
             {params.query && item.hit_count ? (<HitCountBadge className="hit-count--records-" hitCount={item.hit_count} />) : null}
             <MaterialIcon icon="expand_more" />
@@ -232,6 +232,10 @@ const RecordsContent = props => {
     }
   }, [isLoading, preExpanded])
 
+  const collectionDescription = (
+    collection.description || noteText(collection.notes, "abstract") || noteText(collection.notes, "scopecontent")
+  )
+
   return (
   children ?
     (<div className={classnames("records__content", {"hidden": !isContentShown})}>
@@ -242,7 +246,9 @@ const RecordsContent = props => {
       <h2 className="content__title">Collection Content</h2>
       <h3 className="collection__title">{collection.title}</h3>
       <p className="collection__date">{dateString(collection.dates)}</p>
-      <p className="collection__text text--truncate">{collection.description || noteText(collection.notes, "abstract") || noteText(collection.notes, "scopecontent")}</p>
+      <p className="collection__text text--truncate">
+        {truncateString(collectionDescription, 180)}
+      </p>
       <RecordsContentList
         ariaLevel={3}
         className="child__list--top-level"


### PR DESCRIPTION
This was surprisingly non-trivial to figure out. There are a number of libraries out there which will trim a string to the size of its parent container, but I was not a huge fan of introducing another dependency just for a single use. Those also created additional complexities for hit highlighting.

So, what I've done here is a bit of a compromise. I've truncated text to a set character length which is long enough that it just overlaps large screens. I've also kept the CSS styles in place. What this means is that screen readers will generally read a slightly longer string than is visible.

Fixes #264 