### PR TITLE
Displays general notes

### DIFF
--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -13,13 +13,16 @@ export const hasAccessOrUse = notes => {
   return access || use
 }
 
+/** Returns text for a given note */
+export const noteText = note => {
+  return note.subnotes.map(s => s.content).join("\r")
+}
 
 /** Returns text for a specific note (or notes) by type */
-export const noteText = (notes, noteType) => {
+export const noteTextByType = (notes, noteType) => {
   let filteredNotes = notes && notes.filter(n => {return n.type === noteType})
   return filteredNotes ? filteredNotes.map(note => note.subnotes.map(s => s.content)).join("\r") : null
 }
-
 
 /** Adds params (passed as an object) to a URL */
 export const appendParams = (url, params) => {

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -233,7 +233,7 @@ const RecordsContent = props => {
   }, [isLoading, preExpanded])
 
   const collectionDescription = (
-    collection.description || noteText(collection.notes, "abstract") || noteText(collection.notes, "scopecontent")
+    collection.description || noteTextByType(collection.notes, "abstract") || noteTextByType(collection.notes, "scopecontent")
   )
 
   return (

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -12,7 +12,7 @@ import { HitCountBadge } from "../HitCount";
 import ListToggleButton from "../ListToggleButton";
 import MaterialIcon from "../MaterialIcon";
 import QueryHighlighter from "../QueryHighlighter";
-import { appendParams, dateString, noteText } from "../Helpers";
+import { appendParams, dateString, noteTextByType } from "../Helpers";
 import { isItemSaved } from "../MyListHelpers";
 import classnames from "classnames";
 import "./styles.scss";
@@ -242,7 +242,7 @@ const RecordsContent = props => {
       <h2 className="content__title">Collection Content</h2>
       <h3 className="collection__title">{collection.title}</h3>
       <p className="collection__date">{dateString(collection.dates)}</p>
-      <p className="collection__text text--truncate">{collection.description || noteText(collection.notes, "abstract") || noteText(collection.notes, "scopecontent")}</p>
+      <p className="collection__text text--truncate">{collection.description || noteTextByType(collection.notes, "abstract") || noteTextByType(collection.notes, "scopecontent")}</p>
       <RecordsContentList
         ariaLevel={3}
         className="child__list--top-level"

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -12,7 +12,7 @@ import ListToggleButton from "../ListToggleButton";
 import MaterialIcon from "../MaterialIcon";
 import QueryHighlighter from "../QueryHighlighter";
 import { DetailSkeleton, FoundInItemSkeleton } from "../LoadingSkeleton";
-import { appendParams, dateString, hasAccessOrUse, noteText } from "../Helpers";
+import { appendParams, dateString, hasAccessOrUse, noteText, noteTextByType } from "../Helpers";
 import { isItemSaved } from "../MyListHelpers";
 import classnames from "classnames";
 import "./styles.scss";
@@ -50,8 +50,8 @@ const PanelFormatSection = ({ formats, notes }) => {
     f !== "documents"
   ))
   const formatText = []
-  formatText.push(noteText(notes, "physdesc"))
-  formatText.push(noteText(notes, "materialspec"))
+  formatText.push(noteTextByType(notes, "physdesc"))
+  formatText.push(noteTextByType(notes, "materialspec"))
   const filteredFormatText = formatText.filter(i => (i != null))
   return (
     displayFormats.length ? (
@@ -209,13 +209,20 @@ const RecordsDetail = props => {
               <PanelTextSection
                 params={props.params}
                 title="Description"
-                text={noteText(props.item.notes, "abstract") || noteText(props.item.notes, "scopecontent")} />
+                text={noteTextByType(props.item.notes, "abstract") || noteTextByType(props.item.notes, "scopecontent")} />
+              { props.item.notes && props.item.notes.filter(n => n.type === "odd").map(n => (
+                <PanelTextSection
+                params={props.params}
+                title={n.title}
+                text={noteText(n)}
+                />
+              ))}
               {/** Commented out until we're ready to display Processing Information notes */
-              /**{ noteText(props.item.notes, "processinfo") ?
+              /**{ noteTextByType(props.item.notes, "processinfo") ?
                 (<PanelTextSection
                   params={props.params}
                   title="Processing Information"
-                  text={noteText(props.item.notes, "processinfo")} />) :
+                  text={noteTextByType(props.item.notes, "processinfo")} />) :
                 (null)
               }*/}
               </>
@@ -231,10 +238,10 @@ const RecordsDetail = props => {
           <AccordionItemPanel className="accordion__panel">
             <PanelTextSection
               title="Access"
-              text={noteText(props.item.notes, "accessrestrict")} />
+              text={noteTextByType(props.item.notes, "accessrestrict")} />
             <PanelTextSection
               title="Reproduction and Duplication"
-              text={noteText(props.item.notes, "userestrict")} />
+              text={noteTextByType(props.item.notes, "userestrict")} />
           </AccordionItemPanel>
         </AccordionItem>) :
         (null)}


### PR DESCRIPTION
Displays general notes, if they exist, using the note title.

See `/objects/WGHeTV23bg5omNu5L9jMF9?category=&limit=40&query=%22stack%20material%22` for an example.

fixes #259