### PR TITLE
Adds item detail button as a Mirador plugin

### DIFF
--- a/src/components/PageDigitalObject/index.js
+++ b/src/components/PageDigitalObject/index.js
@@ -77,14 +77,25 @@ const PageDigitalObject = props => {
       document.referrer : `/${props.match.params.type}/${props.match.params.id}`
   )
 
+  const BackToItemButton = () => (
+    <nav>
+      <a href={itemUrl} className="btn btn--back-item">
+        <MaterialIcon icon="keyboard_arrow_left"/>Back to Item Details
+      </a>
+    </nav>
+  )
+
+  const plugins = [
+    {
+      mode: 'wrap',
+      component: BackToItemButton,
+      target: 'WindowTopBarPluginArea',
+    }
+  ];
+
   return (
     <div className="digital">
-      <nav>
-        <a href={itemUrl} className="btn btn--back-item">
-          <MaterialIcon icon="keyboard_arrow_left"/>Back to Item Details
-        </a>
-      </nav>
-      <Viewer config={configs} plugins={[]} />
+      <Viewer config={configs} plugins={plugins} />
     </div>
   )
 }

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -151,10 +151,7 @@
 .btn--back-item {
   @extend .btn--black;
   @extend .btn--sm;
-  position: absolute;
-  top: 12px;
-  right: 15px;
-  z-index: 999;
+  margin-top: 10px;
   &:hover {
     color: $light-med-gray;
   }


### PR DESCRIPTION
Uses Mirador plugin instead of floating an absolutely-positioned button on top of Mirador. 

The title is still truncated, but it's now done in a way that looks much less like a mistake.

fixes #248