### PR TITLE
Improve and standardize focus styles

### DIFF
--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -181,7 +181,7 @@ const RecordsDetail = props => {
     }
     <Accordion className="accordion accordion--details" preExpanded={["summary"]} allowZeroExpanded={true}>
       <AccordionItem className="accordion__item" uuid="summary">
-        <AccordionItemHeading className="accordion__heading" ariaLevel={2}>
+        <AccordionItemHeading ariaLevel={2}>
           <AccordionItemButton className="accordion__button">Summary</AccordionItemButton>
         </AccordionItemHeading>
         <AccordionItemPanel className="accordion__panel">
@@ -225,7 +225,7 @@ const RecordsDetail = props => {
       </AccordionItem>
       { hasAccessOrUse(props.item.notes) ?
         (<AccordionItem className="accordion__item" uuid="accessAndUse">
-          <AccordionItemHeading className="accordion__heading" ariaLevel={2}>
+          <AccordionItemHeading ariaLevel={2}>
             <AccordionItemButton className="accordion__button">Access and Use</AccordionItemButton>
           </AccordionItemHeading>
           <AccordionItemPanel className="accordion__panel">
@@ -240,7 +240,7 @@ const RecordsDetail = props => {
         (null)}
       { props.item.terms && props.item.terms.length ?
         (<AccordionItem className="accordion__item" uuid="relatedTerms">
-            <AccordionItemHeading className="accordion__heading" ariaLevel={2}>
+            <AccordionItemHeading ariaLevel={2}>
               <AccordionItemButton className="accordion__button">Related Terms</AccordionItemButton>
             </AccordionItemHeading>
             <AccordionItemPanel className="accordion__panel">

--- a/src/styles/base/_layout.scss
+++ b/src/styles/base/_layout.scss
@@ -1,5 +1,5 @@
 // TODO: factor typography out of here
-// TODO: determine what shold go in separate includes
+// TODO: determine what should go in separate includes
 
 html {
   scroll-behavior: smooth;

--- a/src/styles/base/_normalize.scss
+++ b/src/styles/base/_normalize.scss
@@ -215,12 +215,12 @@ button::-moz-focus-inner,
  * Restore the focus styles unset by the previous rule.
  */
 
-button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
-  outline: 1px dotted ButtonText;
-}
+// button:-moz-focusring,
+// [type="button"]:-moz-focusring,
+// [type="reset"]:-moz-focusring,
+// [type="submit"]:-moz-focusring {
+//   outline: 1px dotted ButtonText;
+// }
 
 /**
  * Correct the padding in Firefox.

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -6,6 +6,19 @@
 // TODO: replace font weights with variables
 // TODO: consider using relative units instead of pixels
 
+@mixin focus-default {
+  outline: solid 2px $med-gray;
+  outline-offset: 2px;
+}
+
+button:focus {
+  @include focus-default;
+}
+
+a:focus {
+  @include focus-default;
+}
+
 p, a {
   font-family: inherit;
   font-weight: $font-weight-normal;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -164,6 +164,7 @@ small {
   text-decoration: underline;
   &:hover, &:focus {
     color: $off-white;
+    text-decoration: none;
     transition: $transition-default;
   }
 }

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -75,7 +75,7 @@ h4 {
 }
 
 a {
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   color: $burnt-orange;
   text-decoration: none;
   transition: $transition-default;
@@ -115,7 +115,7 @@ small {
 
 @mixin footer-primary-title-text {
   font-family: $sans-serif-stack;
-  font-weight: 900;
+  font-weight: $font-weight-heavy;
   font-size: 21px;
   letter-spacing: 4px;
   line-height: 26px;
@@ -124,7 +124,7 @@ small {
 
 @mixin footer-primary-text {
   font-family: $serif-stack;
-  font-weight: 400;
+  font-weight: $font-weight-normal;
   font-size: 15px;
   color: $deep-navy;
   line-height: 22px;
@@ -166,7 +166,7 @@ small {
   text-transform: uppercase;
   letter-spacing: 0.1em;
   line-height: 13px;
-  font-weight: 900;
+  font-weight: $font-weight-heavy;
   &:hover, &:focus {
     color: $off-white;
   }
@@ -184,7 +184,7 @@ small {
 
 @mixin secondary-header-nav-link {
   @include secondary-header-text;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   font-size: 13px;
   letter-spacing: 0.1em;
   line-height: 60px;
@@ -205,7 +205,7 @@ small {
 
 @mixin tile-title-text {
   @include tile-text;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   font-size: 18px;
   color: $dark-gray;
   line-height: 22px;
@@ -213,7 +213,7 @@ small {
 
 @mixin tile-date-text {
   @include tile-text;
-  font-weight: 400;
+  font-weight: $font-weight-normal;
   font-size: 15px;
   color: $dark-gray;
 }
@@ -222,14 +222,14 @@ small {
   @include tile-text;
   font-size: 11px;
   line-height: 11px;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   color: $pure-white;
 }
 
 @mixin tile-type-label-text {
   @include tile-text;
   text-transform: uppercase;
-  font-weight: 900;
+  font-weight: $font-weight-heavy;
   font-size: 12px;
   color: $red-brown;
   letter-spacing: 0.1em;
@@ -270,7 +270,7 @@ small {
 .agent-attribute__label {
   font-family: $sans-serif-stack;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   letter-spacing: 0.65px;
   text-transform: uppercase;
   margin: 0px;
@@ -285,7 +285,7 @@ small {
 
 .hero__text {
   font-family: $serif-stack;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   font-size: 18px;
   line-height: 24px;
   color: $dark-gray;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -82,7 +82,7 @@ a {
   &:focus {
     text-decoration: underline;
   }
-  &:hover {
+  &:hover, &:focus {
     text-decoration: underline;
     color: $red-orange;
     cursor: pointer;
@@ -135,7 +135,7 @@ small {
   @include footer-primary-text;
   text-decoration: underline;
   font-weight: $font-weight-normal;
-  &:hover {
+  &:hover, &:focus {
     color: $burnt-orange;
     transition: $transition-default;
   }
@@ -149,7 +149,7 @@ small {
 @mixin footer-secondary-link {
   @include footer-secondary-text;
   text-decoration: underline;
-  &:hover {
+  &:hover, &:focus {
     color: $off-white;
     transition: $transition-default;
   }
@@ -167,7 +167,7 @@ small {
   letter-spacing: 0.1em;
   line-height: 13px;
   font-weight: 900;
-  &:hover {
+  &:hover, &:focus {
     color: $off-white;
   }
   @include md-up {
@@ -188,7 +188,7 @@ small {
   font-size: 13px;
   letter-spacing: 0.1em;
   line-height: 60px;
-  &:hover {
+  &:hover, &:focus {
     color: $off-white;
   }
   @include md-up  {

--- a/src/styles/components/_accordion.scss
+++ b/src/styles/components/_accordion.scss
@@ -17,7 +17,7 @@
   font-family: inherit;
   font-size: 14px;
   text-transform: uppercase;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   letter-spacing: 2px;
   color: $deep-navy;
   padding: 12px 0px;
@@ -41,7 +41,7 @@
 .panel__heading {
   font-family: inherit;
   font-size: 12px;
-  font-weight: 800;
+  font-weight: $font-weight-extra-bold;
   color: $dark-gray;
   letter-spacing: 0.7px;
   text-transform: uppercase;
@@ -60,7 +60,7 @@
 .panel__text a {
   color: $dark-gray;
   text-decoration: underline;
-  font-weight: normal;
+  font-weight: $font-weight-normal;
 }
 
 .panel__text--narrative {

--- a/src/styles/components/_accordion.scss
+++ b/src/styles/components/_accordion.scss
@@ -9,11 +9,8 @@
   margin-top: 20px;
 }
 
-.accordion__heading {
-  border-bottom: 1px dotted $deep-navy;
-}
-
 .accordion__button {
+  border-bottom: 1px dotted $deep-navy;
   font-family: inherit;
   font-size: 14px;
   text-transform: uppercase;
@@ -24,6 +21,8 @@
   cursor: pointer;
   &:focus {
     outline: none;
+    border-bottom: 1px solid $deep-navy;
+    font-weight: $font-weight-heavy;
   }
   &::after {
     @extend .material-icons;

--- a/src/styles/components/_biographies.scss
+++ b/src/styles/components/_biographies.scss
@@ -23,7 +23,7 @@
     }
     h3 {
       font-family: $sans-serif-stack;
-      font-weight: 900;
+      font-weight: $font-weight-heavy;
       font-size: 15px;
       color: $deep-navy;
       line-height: 18px;

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -179,9 +179,10 @@
     line-height: 58px;
     width: 58px;
   }
-  &:focus {
+  &:focus { //match .btn--orange hover styles
     outline: none;
-    background-color: $red-orange;
+    background: $med-brown;
+    border: 1px solid $med-brown;
   }
 }
 
@@ -190,9 +191,6 @@
   @extend .btn--sm;
   margin-top: 15px;
   margin-bottom: 40px;
-  &:focus {
-
-  }
 }
 
 .btn--dropdown {

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -149,7 +149,7 @@
   @extend .btn--black;
   @extend .btn--sm;
   margin-top: 10px;
-  &:hover {
+  &:hover, &:focus {
     color: $light-med-gray;
   }
   &:focus {

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -92,7 +92,7 @@
   background: $burnt-orange;
   color: $pure-white;
   border: 1px solid $burnt-orange;
-  &:hover, &:focus {
+  &:hover {
     background: $med-brown;
     border: 1px solid $med-brown;
     color: $off-white;
@@ -124,7 +124,7 @@
   background: $light-med-gray;
   color: $pure-white;
   border: 1px solid $light-med-gray;
-  &:hover, &:focus {
+  &:hover {
     background: $orange-gray;
     color: $pure-white;
   }
@@ -155,6 +155,9 @@
   &:hover, &:focus {
     color: $light-med-gray;
   }
+  &:focus {
+    outline: solid 1px $light-med-gray;
+  }
 }
 
 .btn--new-search {
@@ -175,6 +178,10 @@
     font-size: 36px;
     line-height: 58px;
     width: 58px;
+  }
+  &:focus {
+    outline: solid 1px $med-gray;
+    outline-offset: 0px;
   }
 }
 

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -5,10 +5,7 @@
   letter-spacing: 1.5px;
   text-transform: uppercase;
   vertical-align: middle;
-  &:hover {
-    text-decoration: none;
-  }
-  &:focus {
+  &:hover, &:focus {
     text-decoration: none;
   }
 }
@@ -73,7 +70,7 @@
   background: $deep-blue;
   color: $pure-white;
   border: 1px solid $deep-blue;
-  &:hover {
+  &:hover, &:focus {
     background: $dark-blue;
     border: 1px solid $dark-blue;
     color: $pure-white; //for links styled as buttons
@@ -84,7 +81,7 @@
   background: $deep-navy;
   color: $pure-white;
   border: 1px solid $deep-navy;
-  &:hover {
+  &:hover, &:focus {
     background: $deep-blue;
     border: 1px solid $deep-blue;
     color: $off-white;
@@ -95,7 +92,7 @@
   background: $burnt-orange;
   color: $pure-white;
   border: 1px solid $burnt-orange;
-  &:hover {
+  &:hover, &:focus {
     background: $med-brown;
     border: 1px solid $med-brown;
     color: $off-white;
@@ -117,7 +114,7 @@
   background: $off-white;
   color: $med-gray;
   border: 1px solid $light-med-gray;
-  &:hover {
+  &:hover, &:focus {
     background: $lighter-gray;
     color: $med-gray;
   }
@@ -127,7 +124,7 @@
   background: $light-med-gray;
   color: $pure-white;
   border: 1px solid $light-med-gray;
-  &:hover {
+  &:hover, &:focus {
     background: $orange-gray;
     color: $pure-white;
   }
@@ -155,7 +152,7 @@
   top: 12px;
   right: 15px;
   z-index: 999;
-  &:hover {
+  &:hover, &:focus {
     color: $light-med-gray;
   }
 }
@@ -219,7 +216,7 @@
   @extend .btn--sm;
   padding: 8px;
   z-index: 998;
-  &:hover {
+  &:hover, &:focus {
     color: $pure-white;
   }
   & .material-icons {

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -97,6 +97,9 @@
     border: 1px solid $med-brown;
     color: $off-white;
   }
+  &:focus {
+    color: $off-white;
+  }
   &:disabled {
     background: $burnt-orange;
     color: $pure-white;
@@ -187,6 +190,9 @@
   @extend .btn--sm;
   margin-top: 15px;
   margin-bottom: 40px;
+  &:focus {
+
+  }
 }
 
 .btn--dropdown {

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -34,7 +34,7 @@
 
 .btn--sm {
   font-size: 10px;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   line-height: 16px;
   padding: 8px 10px;
   margin-right: 10px;
@@ -56,7 +56,7 @@
 }
 
 .btn--lg {
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   font-size: 14px;
   line-height: 18px;
   padding: 18px;

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -180,8 +180,8 @@
     width: 58px;
   }
   &:focus {
-    outline: solid 1px $med-gray;
-    outline-offset: 0px;
+    outline: none;
+    background-color: $red-orange;
   }
 }
 

--- a/src/styles/components/_collection-hits.scss
+++ b/src/styles/components/_collection-hits.scss
@@ -14,7 +14,7 @@
 .collection-hits__title {
   @include collection-hits-text;
   font-size: 12px;
-  font-weight: bold;
+  font-weight: $font-weight-bold;
   text-transform: uppercase;
   color: $dark-gray;
   letter-spacing: 0.5px;

--- a/src/styles/components/_context-switcher.scss
+++ b/src/styles/components/_context-switcher.scss
@@ -32,7 +32,7 @@
     opacity: 1;
     background: $off-white;
     color: $dark-gray;
-    &:hover {
+    &:hover, &:focus {
       background: $neutral-sand;
       color: $dark-gray;
     }

--- a/src/styles/components/_facet.scss
+++ b/src/styles/components/_facet.scss
@@ -10,7 +10,7 @@
 .facet__title {
   text-transform: uppercase;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   margin-top: 0;
 }
 
@@ -40,7 +40,7 @@
 .facet__show-hide {
   font-family: $sans-serif-stack;
   font-size: 12px;
-  font-weight: normal;
+  font-weight: $font-weight-normal;
   color: $deep-navy;
   text-decoration: underline;
   appearance: none;

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -239,8 +239,8 @@ label {
     pointer-events: none;
   }
   &:focus {
-    outline: solid 1px $med-gray;
-    outline-offset: 0px;
+    outline: none;
+    font-weight: 700;
   }
 }
 

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -93,7 +93,7 @@ label {
 }
 
 .checkbox:focus + label:before {
-  outline: 2px solid $dark-gray;
+  outline: 2px solid $med-gray;
 }
 
 /* checked mark aspect changes */

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -240,7 +240,7 @@ label {
   }
   &:focus {
     outline: none;
-    font-weight: 700;
+    font-weight: $font-weight-bold;
   }
 }
 

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -156,7 +156,7 @@ label {
 }
 
 .dp__month {
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   padding: 0 16px;
   text-align: center;
   width: 200px;
@@ -186,7 +186,7 @@ label {
 
   th {
     color: $med-gray;
-    font-weight: 400;
+    font-weight: $font-weight-normal;
     line-height: 1.6;
   }
 
@@ -255,7 +255,7 @@ label {
     background: $lighter-gray;
   }
   &.is-selected {
-    font-weight: 700;
+    font-weight: $font-weight-bold;
     &::after {
       @extend .material-icons;
       font-size: 20px;

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -230,6 +230,10 @@ label {
     position: absolute;
     pointer-events: none;
   }
+  &:focus {
+    outline: solid 1px $med-gray;
+    outline-offset: 0px;
+  }
 }
 
 .select__menu {

--- a/src/styles/components/_material-icon.scss
+++ b/src/styles/components/_material-icon.scss
@@ -1,10 +1,12 @@
+@import "../styles";
+
 .material-icons {
     direction: ltr;
     display: inline-block;
     font-family: 'Material Icons';
     font-size: 24px;
     font-style: normal;
-    font-weight: normal;
+    font-weight: $font-weight-normal;
     letter-spacing: normal;
     vertical-align: middle;
     text-transform: none;

--- a/src/styles/components/_modal-mylist.scss
+++ b/src/styles/components/_modal-mylist.scss
@@ -64,7 +64,7 @@
 }
 
 .modal-form label {
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   margin-bottom: 5px;
   &[for=costs] {
     float: none;
@@ -77,7 +77,7 @@
 
 // font-weight for checkboxes
 .modal-form input[type=checkbox] + label {
-  font-weight: normal;
+  font-weight: $font-weight-normal;
 }
 
 .modal-form .help-text {

--- a/src/styles/components/_modal-saved-item.scss
+++ b/src/styles/components/_modal-saved-item.scss
@@ -14,7 +14,7 @@
   list-style: none;
   padding-left: 0;
   font-size: 15px;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   color: $dark-gray;
 }
 

--- a/src/styles/components/_nav.scss
+++ b/src/styles/components/_nav.scss
@@ -28,9 +28,9 @@
   display: inline-block;
   border-left: 1px solid $med-gray;
   position: relative;
-  &:hover {
+  &:hover, &:focus-within {
     background-color: $deep-blue;
-    transition: $transition-default
+    transition: $transition-default;
   }
   @include md-up {
     padding-left: 14px;
@@ -39,6 +39,9 @@
 }
 .nav__link {
   @include secondary-header-nav-link;
+  &:focus {
+    outline: none;
+  }
   &::before {
     content: "";
     position: absolute;

--- a/src/styles/components/_pagination.scss
+++ b/src/styles/components/_pagination.scss
@@ -15,9 +15,9 @@
   & a {
     @extend .material-icons;
     font-size: 23px;
-    line-height: 0;
-    margin-bottom: 5px;
-    &:hover {
+    line-height: 23px;
+    margin-bottom: 3px;
+    &:hover, &:focus {
       text-decoration: none;
     }
   }

--- a/src/styles/components/_pagination.scss
+++ b/src/styles/components/_pagination.scss
@@ -26,7 +26,7 @@
 .pagination__button.disabled a, .page__active a{
   color: $dark-gray;
   cursor: default;
-  &:hover {
+  &:hover, &:focus {
     color: inherit;
     cursor: inherit;
     text-decoration: none;

--- a/src/styles/components/_records-content.scss
+++ b/src/styles/components/_records-content.scss
@@ -233,7 +233,7 @@
   border: none;
   background: none;
   text-align: left;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   cursor: pointer;
   padding-left: 0;
   padding-right: 20px;

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -68,6 +68,6 @@
   font-family: inherit;
   color: inherit;
   font-size: inherit;
-  font-weight: normal;
+  font-weight: $font-weight-normal;
   text-decoration: underline;
 }

--- a/src/styles/components/_saved-item.scss
+++ b/src/styles/components/_saved-item.scss
@@ -83,7 +83,7 @@
   & a {
     @include saved-item-text;
     color: $dark-gray;
-    font-weight: normal;
+    font-weight: $font-weight-normal;
     text-decoration: underline;
   }
 }

--- a/src/styles/components/_skip-link.scss
+++ b/src/styles/components/_skip-link.scss
@@ -11,7 +11,7 @@
   font-size: 18px;
   font-weight: 700;
   text-align: center;
-  &:hover {
+  &:hover, &:focus {
     color: $off-white;
   }
 }

--- a/src/styles/components/_skip-link.scss
+++ b/src/styles/components/_skip-link.scss
@@ -9,7 +9,7 @@
   left: 80px;
   top: 60px;
   font-size: 18px;
-  font-weight: 700;
+  font-weight: $font-weight-bold;;
   text-align: center;
   &:hover, &:focus {
     color: $off-white;

--- a/src/styles/components/_skip-link.scss
+++ b/src/styles/components/_skip-link.scss
@@ -11,7 +11,7 @@
   font-size: 18px;
   font-weight: $font-weight-bold;;
   text-align: center;
-  &:hover, &:focus {
+  &:focus {
     color: $off-white;
   }
 }

--- a/src/styles/components/_social-icons.scss
+++ b/src/styles/components/_social-icons.scss
@@ -13,7 +13,7 @@
   width: 40px;
   text-align: center;
   vertical-align: middle;
-  &:hover, &:focus {
+  &:hover {
     svg g, svg path {
       fill: $burnt-orange;
       transition: $transition-default;

--- a/src/styles/components/_social-icons.scss
+++ b/src/styles/components/_social-icons.scss
@@ -13,7 +13,7 @@
   width: 40px;
   text-align: center;
   vertical-align: middle;
-  &:hover {
+  &:hover, &:focus {
     svg g, svg path {
       fill: $burnt-orange;
       transition: $transition-default;

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -55,7 +55,7 @@
   width: 100%;
   border-bottom: none;
   order: 2;
-  &:hover {
+  &:hover, &:focus {
     text-decoration: none;
     color: $dark-gray;
   }

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -40,9 +40,11 @@ $gutters-default: 15px;
 // Typography
 $sans-serif-stack: 'Lato', sans-serif;
 $serif-stack: 'Manuale', serif;
+$font-weight-light: 300;
 $font-weight-normal: 400;
 $font-weight-bold: 700;
-$font-weight-light: 300;
+$font-weight-extra-bold: 800;
+$font-weight-heavy: 900;
 
 //Modals
 $modal-content-margin: 10%;


### PR DESCRIPTION
Standardizes button and link focus styles across browsers, adds focus styles where there were none, and makes the focus indicators a little more strident and easier to see. I tried to balance the aesthetics so things aren't too distracting for mouse users, but I'd love a tab-through to check that these look ok (including the accordion buttons in record details).

I didn't mess too much with the browser default styles for inputs.

Fixes #66 