### PR TITLE
Correctly pluralize words

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "formik": "^2.1.5",
     "mirador": "^3.0.0",
     "node-sass": "^4.14.1",
+    "pluralize": "^8.0.0",
     "react": "^16.13.1",
     "react-accessible-dropdown-menu-hook": "^2.1.1",
     "react-aria-live": "^2.0.5",

--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -59,7 +59,11 @@ export const truncateString = (text, maxLength) => {
     if (text.length < maxLength) {
       return text
     }
-    return text.substr(0, text.indexOf(" ", maxLength)) + "...";
+    if (text.indexOf(" ", maxLength) > 0) {
+      return text.substr(0, text.indexOf(" ", maxLength)) + "...";
+    } else {
+      return text + "...";
+    }
   } else {
     return null
   }

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Formik, Form, Field, ErrorMessage, useFormikContext } from "formik";
+import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import Button from "../Button";
 import Modal from "react-modal";
@@ -105,7 +106,7 @@ const SelectedTotals = ({ items }) => {
       {...total, [current.type]: total[current.type] + parseFloat(current.value)} :
       {...total, [current.type]: parseFloat(current.value)}
   ), {})
-  const extents = Object.entries(totals).map(e => `${e[1]} ${e[1] === 1 ? e[0] : `${e[0]}s`}`)
+  const extents = Object.entries(totals).map(e => pluralize(e[0], e[1], true))
   return (extents.length ? <p className="selected-totals">{`selected: ${extents.join(", ")}`}</p> : <p className="selected-totals">selected: 0 items</p>)
 }
 

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -39,8 +39,12 @@ const PanelExtentSection = ({ extents }) => (
   <div className="panel__section">
     <h3 className="panel__heading">Size</h3>
     <ul className="panel__list--unstyled">
-      {extents.map((e, index) => (
-      <li key={index} className="panel__text">{pluralize(e.type.replace("_", " "), e.value, true)}</li>))}
+      {extents.map((e, index) => {
+        const extentArray = e.type.replace("_", " ").split(" ").map((ext, i, arr) => (
+          arr.length - 1 === i ? pluralize(ext, e.value) : ext
+        ))
+        return (
+      <li key={index} className="panel__text">{`${e.value} ${extentArray.join(" ")}`}</li>)})}
     </ul>
   </div>) :
   (null)

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import Skeleton from "react-loading-skeleton";
 import {
@@ -39,7 +40,7 @@ const PanelExtentSection = ({ extents }) => (
     <h3 className="panel__heading">Size</h3>
     <ul className="panel__list--unstyled">
       {extents.map((e, index) => (
-      <li key={index} className="panel__text">{`${e.value} ${e.type.replace("_", " ")}`}</li>))}
+      <li key={index} className="panel__text">{pluralize(e.type.replace("_", " "), e.value, true)}</li>))}
     </ul>
   </div>) :
   (null)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8801,6 +8801,11 @@ pkg-up@3.1.0, pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"


### PR DESCRIPTION
Uses the `pluralize` library to pluralize extents in MyList modals and RecordDetail components.

Also includes a tweak to the string length calculation for cases where the string is very close to the max length.