### PR TITLE
Hides download and view buttons for digital assets when they are missing

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 REACT_APP_ARGO_BASEURL=http://api.rockarch.org
 REACT_APP_REQUEST_BROKER_BASEURL=http://rac-vch.ad.rockarchive.org:8001/api
 REACT_APP_LOCALSTORAGE_KEY=DIMESMyList
+REACT_APP_S3_BASEURL=https://iiif.rockarch.org

--- a/src/components/PageRecords/index.js
+++ b/src/components/PageRecords/index.js
@@ -58,7 +58,6 @@ class PageRecords extends Component {
               this.setState({ downloadSize: formatBytes(res.headers["content-length"]) })
             })
             .catch(e => {
-              console.log(e);
               this.setState({ downloadSize: "" })
             })
         }

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -44,7 +44,7 @@ class RecordsChild extends Component {
           {...this.props.params, limit: 5})
         )
     }
-    this.handleOnlineAsset(this.props.item.uri.split("/").pop())
+    this.props.item.online && this.handleOnlineAsset(this.props.item.uri.split("/").pop())
     if (this.props.item.uri === currentUrl) {
       const el = document.getElementById(`accordion__heading-${currentUrl}`)
       el.scrollIntoView({ behavior: "smooth", block: "center" })

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -24,6 +24,7 @@ class RecordsChild extends Component {
     this.state = {
       children: [],
       isSaved: false,
+      hasOnlineAsset: false,
     }
   }
 
@@ -43,6 +44,7 @@ class RecordsChild extends Component {
           {...this.props.params, limit: 5})
         )
     }
+    this.handleOnlineAsset(this.props.item.uri.split("/").pop())
     if (this.props.item.uri === currentUrl) {
       const el = document.getElementById(`accordion__heading-${currentUrl}`)
       el.scrollIntoView({ behavior: "smooth", block: "center" })
@@ -82,6 +84,13 @@ class RecordsChild extends Component {
     this.props.setActiveRecords(uri)
   }
 
+  handleOnlineAsset = identifier => {
+    axios
+      .head(`${process.env.REACT_APP_S3_BASEURL}/pdfs/${identifier}`)
+      .then(res => { this.setState({ hasOnlineAsset: true }) })
+      .catch(e => { this.setState({ hasOnlineAsset: false }) })
+  }
+
   toggleSaved = item => {
     this.props.toggleInList(item);
     this.setState({isSaved: !this.state.isSaved})
@@ -104,7 +113,7 @@ class RecordsChild extends Component {
           {item.dates === item.title ? (null) : (<p className="child__text">{item.dates}</p>)}
         </div>
         <div className="child__buttons">
-          {item.online ? (
+          {this.state.hasOnlineAsset ? (
             <a className="btn btn-launch--content"
                href={`${item.uri}/view`}>{isMobile? "View" : "View Online"}
                <MaterialIcon icon="visibility" /></a>) :

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -156,33 +156,27 @@ const RecordsDetail = props => {
       </a>
     </nav>
     <h1 className="records__title">{props.isItemLoading ? <Skeleton /> : props.item.title }</h1>
-    {props.item.type === "object" ?
-      (props.item.online ? (
-        <>
-        <ListToggleButton
-          className="btn-add--detail"
-          isSaved={isSaved}
-          item={props.item}
-          toggleSaved={props.toggleInList} />
-        <a className="btn btn-launch--detail"
-          href={`${props.item.uri}/view`}>View Online <MaterialIcon icon="visibility" /></a>
-        <a className="btn btn-download--detail"
-          href={`${process.env.REACT_APP_S3_BASEURL}/pdfs/${identifier}`}
-          target="_blank"
-          title="opens in a new window"
-          rel="noopener noreferrer"
-          >Download <MaterialIcon icon="get_app" /></a>
-          {props.downloadSize ?
-            (<p className="panel__text">{`Acrobat PDF, ${props.downloadSize}`}</p>) :
-            (null)}
-        </>
-      ) :
-      (<ListToggleButton
+    {props.item.type === "object" &&
+      <>
+      <ListToggleButton
         className="btn-add--detail"
         isSaved={isSaved}
         item={props.item}
-        toggleSaved={props.toggleInList} />)
-      ): (null)
+        toggleSaved={props.toggleInList} />
+        {props.downloadSize &&
+          <>
+          <a className="btn btn-launch--detail"
+            href={`${props.item.uri}/view`}>View Online <MaterialIcon icon="visibility" /></a>
+          <a className="btn btn-download--detail"
+            href={`${process.env.REACT_APP_S3_BASEURL}/pdfs/${identifier}`}
+            target="_blank"
+            title="opens in a new window"
+            rel="noopener noreferrer"
+            >Download <MaterialIcon icon="get_app" /></a>
+            <p className="panel__text">{`Acrobat PDF, ${props.downloadSize}`}</p>
+          </>
+        }
+      </>
     }
     <Accordion className="accordion accordion--details" preExpanded={["summary"]} allowZeroExpanded={true}>
       <AccordionItem className="accordion__item" uuid="summary">

--- a/src/components/SavedItem/index.js
+++ b/src/components/SavedItem/index.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, {useEffect, useState} from "react";
+import axios from "axios";
 import PropTypes from "prop-types";
 import Button from "../Button";
 import MaterialIcon from "../MaterialIcon";
@@ -6,7 +7,17 @@ import { MyListSkeleton } from "../LoadingSkeleton";
 import "./styles.scss";
 
 
-const SavedItem = props => (
+const SavedItem = props => {
+  const [hasOnlineAsset, setHasOnlineAsset] = useState(false)
+
+  useEffect(() => {
+    axios
+      .head(`${process.env.REACT_APP_S3_BASEURL}/pdfs/${props.uri.split("/").pop()}`)
+      .then(res => { setHasOnlineAsset(true) })
+      .catch(e => { setHasOnlineAsset(false) })
+  }, [props.uri])
+
+  return (
   <div className="saved-item">
     <div className="saved-item__row">
       <div className="saved-item__item-description">
@@ -17,7 +28,7 @@ const SavedItem = props => (
         {props.lastRequested && <p className="saved-item__last-requested">Last requested on: {props.lastRequested}</p>}
       </div>
       <div className="saved-item__buttons">
-        {props.online &&
+        {hasOnlineAsset &&
           <a className="btn btn--blue btn--sm"
             href={`${props.uri}/view`}>View Online <MaterialIcon icon="visibility" /></a>}
         <Button
@@ -27,7 +38,7 @@ const SavedItem = props => (
           handleClick={props.handleClick} />
       </div>
     </div>
-  </div>)
+  </div>)}
 
 SavedItem.propTypes = {
   date: PropTypes.string,


### PR DESCRIPTION
In order to cover cases where a digital asset has not yet been uploaded for a digital object, added logic to hide download and view buttons when a `HEAD` request against the PDF asset fails.

This was done in the RecordsDetail, RecordsContent and MyList components/pages

fixes #292 