### PR TITLE
Uses "1 item" as default for Objects without extents

### DIFF
--- a/src/__fixtures__/checkedList.js
+++ b/src/__fixtures__/checkedList.js
@@ -126,5 +126,23 @@ export const checkedList = [{
     "parent_ref": "/collections/ChqRRrDVPGqYiDftR4WszC",
     "online": false,
     "archivesspace_uri": "/repositories/2/archival_objects/1120786"
+  }, {
+    "isChecked": true,
+    "title": "Barry Goldwater shakes Nelson A. Rockefeller's hand",
+    "uri": "/objects/h2uFAr5Lqe5rHYTPg45vuW",
+    "dates": [{
+      "expression": "1960 July 25",
+      "end": "1960-07-25",
+      "label": "creation",
+      "source": "archivesspace",
+      "type": "single",
+      "begin": "1960-07-25"
+    }],
+    "extents": null,
+    "notes": [],
+    "parent": "Chicago, GOP Convention",
+    "parent_ref": "/collections/Ac4QpG4hRL8M9TWchMERBL",
+    "online": false,
+    "archivesspace_uri": "/repositories/2/archival_objects/472103"
   }]
 }]

--- a/src/components/ModalMyList/__tests__/ModalMyList.test.js
+++ b/src/components/ModalMyList/__tests__/ModalMyList.test.js
@@ -58,7 +58,7 @@ it('renders correctly', () => {
   })
 
   expect(selectButton.textContent).toContain("Deselect all items")
-  expect(totals.textContent).toBe("selected: 2 audio tapes, 9 folders")
+  expect(totals.textContent).toBe("selected: 2 audio tapes, 9 folders, 1 item")
 });
 
 it('renders without crashing', () => {

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -97,6 +97,10 @@ export const ModalToggleListButton = ({ ignoreRestrictions, items, toggleList })
   )
 }
 
+/** Calculates total extent of selected items
+* Only checked items are included in this calculation. A default of "1 item" is
+* provided for items with no extents (which usually means no instance).
+*/
 export const SelectedTotals = ({ items }) => {
   const selectedExtents = items.map(
     g => g.items.filter(i => i.isChecked).map(

--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -99,8 +99,8 @@ export const ModalToggleListButton = ({ ignoreRestrictions, items, toggleList })
 
 export const SelectedTotals = ({ items }) => {
   const selectedExtents = items.map(
-    g => g.items.map(
-      i => i.isChecked ? i.extents : null)).flat(2).filter(i => i !== null)
+    g => g.items.filter(i => i.isChecked).map(
+      i => i.extents ? i.extents: {"type": "item", "value": 1} )).flat(2)
   const totals = selectedExtents.reduce((total, current) => (
     total[current.type] ?
       {...total, [current.type]: total[current.type] + parseFloat(current.value)} :


### PR DESCRIPTION
When objects have no extent (which usually means that there is no instance in AS), a default selected extent value of "1 item" is used in the MyList modal.

Fixes #335 