### PR TITLE
Highlights entire query phrase

### DIFF
--- a/src/components/QueryHighlighter/__tests__/QueryHighligher.test.js
+++ b/src/components/QueryHighlighter/__tests__/QueryHighligher.test.js
@@ -15,7 +15,7 @@ afterEach(() => {
   container = null;
 });
 
-it('renders props correctly', () => {
+it('finds word at beginning', () => {
   act(() => {
     render(<QueryHighlighter query="foo" text="foo bar baz" />, container);
   })
@@ -24,7 +24,7 @@ it('renders props correctly', () => {
   expect(highlight.textContent).toBe("foo")
 });
 
-it('renders props correctly', () => {
+it('finds word in middle', () => {
   act(() => {
     render(<QueryHighlighter query="bar baz" text="foo bar baz" />, container);
   })
@@ -34,7 +34,17 @@ it('renders props correctly', () => {
 
 });
 
-it('renders props correctly', () => {
+it('finds phrase', () => {
+  act(() => {
+    render(<QueryHighlighter query="foo bar" text="foo bar baz" />, container);
+  })
+
+  const highlight = document.querySelector(".query-highlight")
+  expect(highlight.textContent).toBe("foo")
+
+});
+
+it('finds phrase separated by another word', () => {
   act(() => {
     render(<QueryHighlighter query="foo baz" text="foo bar baz" />, container);
   })

--- a/src/components/QueryHighlighter/index.js
+++ b/src/components/QueryHighlighter/index.js
@@ -1,17 +1,37 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Highlighter from "react-highlight-words";
+import { findChunks } from "highlight-words-core";
 import "./styles.scss";
 
 
+/** Custom function which mimics boolean search behavior
+* Only highlights text from a string when all words from search query
+* are present in that string.
+*/
+const findChunksBoolean = ({
+    autoEscape,
+    caseSensitive,
+    sanitize,
+    searchWords,
+    textToHighlight
+  }) => {
+    if (searchWords.every(word => textToHighlight.toLowerCase().includes(word.toLowerCase()))) {
+      return findChunks({autoEscape, caseSensitive, sanitize, searchWords, textToHighlight})
+    } else {
+      return []
+    }
+  };
+
 const QueryHighlighter = ({ query, text }) => {
-  const parsedQuery = query ? [query.replace(/"([^"]+(?="))"/g, '$1')] : []
+  const parsedQuery = query ? query.replace(/"([^"]+(?="))"/g, '$1').split(" ") : []
   return (
     <Highlighter
         highlightClassName="query-highlight"
         searchWords={parsedQuery}
         autoEscape={true}
         textToHighlight={text ? text : ""}
+        findChunks={findChunksBoolean}
       />
     )
   }

--- a/src/components/QueryHighlighter/index.js
+++ b/src/components/QueryHighlighter/index.js
@@ -5,7 +5,7 @@ import "./styles.scss";
 
 
 const QueryHighlighter = ({ query, text }) => {
-  const parsedQuery = query ? query.replace(/"([^"]+(?="))"/g, '$1').split(" ") : []
+  const parsedQuery = query ? [query.replace(/"([^"]+(?="))"/g, '$1')] : []
   return (
     <Highlighter
         highlightClassName="query-highlight"


### PR DESCRIPTION
Removes `split` on spaces, so entire query phrase is highlighted.

Fixes #340 