### PR TITLE
Remove HEAD requests and associated code

### DIFF
--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -24,7 +24,6 @@ export class RecordsChild extends Component {
     this.state = {
       children: [],
       isSaved: false,
-      hasOnlineAsset: false,
     }
   }
 
@@ -44,7 +43,6 @@ export class RecordsChild extends Component {
           {...this.props.params, limit: 5})
         )
     }
-    this.props.item.online && this.handleOnlineAsset(this.props.item.uri.split("/").pop())
     if (this.props.item.uri === currentUrl) {
       const el = document.getElementById(`accordion__heading-${currentUrl}`)
       el.scrollIntoView({ behavior: "smooth", block: "center" })
@@ -84,13 +82,6 @@ export class RecordsChild extends Component {
     this.props.setActiveRecords(uri)
   }
 
-  handleOnlineAsset = identifier => {
-    axios
-      .head(`${process.env.REACT_APP_S3_BASEURL}/pdfs/${identifier}`)
-      .then(res => { this.setState({ hasOnlineAsset: true }) })
-      .catch(e => { this.setState({ hasOnlineAsset: false }) })
-  }
-
   toggleSaved = item => {
     this.props.toggleInList(item);
     this.setState({isSaved: !this.state.isSaved})
@@ -113,7 +104,7 @@ export class RecordsChild extends Component {
           {item.dates === item.title ? (null) : (<p className="child__text">{item.dates}</p>)}
         </div>
         <div className="child__buttons">
-          {this.state.hasOnlineAsset ? (
+          {item.online ? (
             <a className="btn btn-launch--content"
                href={`${item.uri}/view`}>{isMobile? "View" : "View Online"}
                <MaterialIcon icon="visibility" /></a>) :

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -161,7 +161,7 @@ const RecordsDetail = props => {
         isSaved={isSaved}
         item={props.item}
         toggleSaved={props.toggleInList} />
-        {props.downloadSize &&
+        {props.item.online &&
           <>
           <a className="btn btn-launch--detail"
             href={`${props.item.uri}/view`}>View Online <MaterialIcon icon="visibility" /></a>
@@ -171,7 +171,9 @@ const RecordsDetail = props => {
             title="opens in a new window"
             rel="noopener noreferrer"
             >Download <MaterialIcon icon="get_app" /></a>
-            <p className="panel__text">{`Acrobat PDF, ${props.downloadSize}`}</p>
+            { props.downloadSize ?
+              <p className="panel__text">{`Acrobat PDF, ${props.downloadSize}`}</p> :
+              <p className="panel__text"><Skeleton/></p> }
           </>
         }
       </>

--- a/src/components/SavedItem/index.js
+++ b/src/components/SavedItem/index.js
@@ -1,5 +1,4 @@
-import React, {useEffect, useState} from "react";
-import axios from "axios";
+import React from "react";
 import PropTypes from "prop-types";
 import Button from "../Button";
 import MaterialIcon from "../MaterialIcon";
@@ -8,17 +7,7 @@ import { dateString, truncateString } from "../Helpers";
 import "./styles.scss";
 
 
-const SavedItem = props => {
-  const [hasOnlineAsset, setHasOnlineAsset] = useState(false)
-
-  useEffect(() => {
-    axios
-      .head(`${process.env.REACT_APP_S3_BASEURL}/pdfs/${props.uri.split("/").pop()}`)
-      .then(res => { setHasOnlineAsset(true) })
-      .catch(e => { setHasOnlineAsset(false) })
-  }, [props.uri])
-
-  return (
+const SavedItem = props => (
   <div className="saved-item">
     <div className="saved-item__row">
       <div className="saved-item__item-description">
@@ -29,7 +18,7 @@ const SavedItem = props => {
         {props.lastRequested && <p className="saved-item__last-requested">Last requested on: {props.lastRequested}</p>}
       </div>
       <div className="saved-item__buttons">
-        {hasOnlineAsset &&
+        {props.online &&
           <a className="btn btn--blue btn--sm"
             href={`${props.uri}/view`}>View Online <MaterialIcon icon="visibility" /></a>}
         <Button
@@ -39,7 +28,7 @@ const SavedItem = props => {
           handleClick={props.handleClick} />
       </div>
     </div>
-  </div>)}
+  </div>)
 
 SavedItem.propTypes = {
   date: PropTypes.string,


### PR DESCRIPTION
Removes `HEAD` requests which confirm that an online asset exists, as we have now moved that functionality to the data pipeline. Fixes #348 