### PR TITLE
Separate type dropdown from search input and group with digital object checkbox

### DIFF
--- a/src/components/Inputs/index.js
+++ b/src/components/Inputs/index.js
@@ -37,6 +37,7 @@ export const CheckBoxInput = props => (
       name={props.name ? props.name : props.id}
       onChange={props.handleChange}
       checked={props.checked}
+      value={props.checked}
       required={props.required}
       disabled={props.disabled} />
     <InputLabel {...props} />

--- a/src/components/ModalSearch/__tests__/ModalSearch.test.js
+++ b/src/components/ModalSearch/__tests__/ModalSearch.test.js
@@ -29,8 +29,6 @@ it('renders props correctly', () => {
       toggleModal={jest.fn()} />, container)
   })
 
-  const online = document.querySelector('[for=online]')
-  expect(online.textContent).toBe('Show me digital materials only (50)')
   const startYear = document.querySelector('#startYear')
   expect(startYear.value).toBe('-8867404800000')
   const endYear = document.querySelector('#endYear')

--- a/src/components/ModalSearch/index.js
+++ b/src/components/ModalSearch/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Modal from 'react-modal'
 import Button from '../Button'
 import Facet from '../Facet'
-import { CheckBoxInput, YearInput } from '../Inputs'
+import { YearInput } from '../Inputs'
 import MaterialIcon from '../MaterialIcon'
 import './styles.scss'
 
@@ -38,15 +38,6 @@ export const FacetModal = props => {
         </button>
       </div>
       <div className='modal-body--search'>
-        <Facet title='View Online'>
-          <CheckBoxInput
-            id='online'
-            name='true'
-            className='facet__input checkbox--blue'
-            checked={props.params.online === 'true'}
-            handleChange={e => props.handleChange(e, 'online')}
-            label={`Show me digital materials only (${props.data.online && props.data.online.doc_count})`} />
-        </Facet>
         <Facet title='Date Range'>
           <YearInput
             id='startYear'

--- a/src/components/PageDigitalObject/__tests__/PageDigitalObject.test.js
+++ b/src/components/PageDigitalObject/__tests__/PageDigitalObject.test.js
@@ -22,7 +22,6 @@ jest.mock('axios')
 
 it('renders props correctly', async () => {
   axios.get.mockImplementation((url) => {
-    console.log(url);
     if (url.includes('objects')) {
       return Promise.resolve({data: object})
     } else {

--- a/src/components/PageSearch/index.js
+++ b/src/components/PageSearch/index.js
@@ -149,6 +149,7 @@ class PageSearch extends Component {
             <SearchForm
               className='search-form--results'
               query={this.state.params.query}
+              online={this.state.params.online}
               category={this.state.params.category} />
           </div>
           <div className='results'>

--- a/src/components/SearchForm/__tests__/Search.test.js
+++ b/src/components/SearchForm/__tests__/Search.test.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import { render } from 'react-dom'
 import { act } from 'react-dom/test-utils'
-import Search from '..'
+import SearchForm from '..'
 
 it('renders props correctly', () => {
   const div = document.createElement('div')
   document.body.appendChild(div)
 
   act(() => {
-    render(<Search className='foo' />, div)
+    render(<SearchForm className='foo' />, div)
   })
 
   const wrapper = document.querySelector('form > .wrapper > div')

--- a/src/components/SearchForm/__tests__/Search.test.js
+++ b/src/components/SearchForm/__tests__/Search.test.js
@@ -11,6 +11,6 @@ it('renders props correctly', () => {
     render(<Search className='foo' />, div)
   })
 
-  const wrapper = document.querySelector('form > div')
+  const wrapper = document.querySelector('form > .wrapper > div')
   expect(wrapper.className).toBe('foo')
 })

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -15,7 +15,7 @@ const SearchForm = props => {
   }, [props.category, props.query])
 
   const selectOptions = [
-    { value: '', label: 'Everything' },
+    { value: '', label: 'All Types' },
     { value: 'collection', label: 'Collections' },
     { value: 'person', label: 'People' },
     { value: 'organization', label: 'Organizations'}

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -27,7 +27,7 @@ const SearchForm = props => {
 
   return (
     <form className='form--search' role='search' action='/search' method='get'>
-      <div class="wrapper">
+      <div className="wrapper">
         <div className={props.className}>
           <div className={classnames('input-group__search', { 'input-group__search-results': !isHomePage })}>
             <TextInput

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -47,6 +47,7 @@ const SearchForm = props => {
               type='submit'
               label={isHomePage ? (isMobile ? null : 'Search' ) : null}
               iconAfter='search'
+              ariaLabel='Submit search'
             />
           </div>
           <div className={classnames(

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import classnames from 'classnames'
 import Button from '../Button'
 import PropTypes from 'prop-types'
 import { CheckBoxInput, SelectInput, TextInput } from '../Inputs'
@@ -8,6 +9,7 @@ const SearchForm = props => {
   var [category, setCategory] = useState(props.category || '')
   var [online, setOnline] = useState(props.online)
   var [query, setQuery] = useState(props.query)
+  const isHomePage = props.className === 'search-form--home'
 
   /** Sets the search category, query and online checkbox */
   useEffect(() => {
@@ -24,47 +26,51 @@ const SearchForm = props => {
   ]
 
   return (
-    <form role='search' action='/search' method='get'>
-      <div className={props.className}>
-        <div className='input-group__search'>
-          <TextInput
-            className='hide-label input__search'
-            label='Enter a search term'
-            id='query'
-            placeholder='Search...'
-            size={60}
-            value={query || ''}
-            handleChange={e => setQuery(e.target.value)}
-            type='search'
-            required
-          />
-          <Button
-            className='btn--search'
-            type='submit'
-            label='Search'
-            iconAfter='search'
-          />
-        </div>
-        <div className='input-group__search-controls'>
-          <SelectInput
-            className='select__search'
-            hideLabel
-            iconAfter='expand_more'
-            id='category'
-            label='Choose a search category'
-            name='category'
-            onChange={({selectedItem}) => setCategory(selectedItem.value)}
-            options={selectOptions}
-            selectedItem={category || ''}
-          />
-          <CheckBoxInput
-            id='online'
-            name='online'
-            className='checkbox--blue checkbox--online input--outline'
-            checked={online}
-            handleChange={e => setOnline(e.target.checked)}
-            label='Show only results with digital matches'
-          />
+    <form className='form--search' role='search' action='/search' method='get'>
+      <div class="wrapper">
+        <div className={props.className}>
+          <div className={classnames('input-group__search', { 'input-group__search-results': !isHomePage })}>
+            <TextInput
+              className={classnames('hide-label', 'input__search', { 'input__search-results': !isHomePage })}
+              label='Enter a search term'
+              id='query'
+              placeholder='Search...'
+              size={60}
+              value={query || ''}
+              handleChange={e => setQuery(e.target.value)}
+              type='search'
+              required
+            />
+            <Button
+              className={classnames({ 'btn--search': isHomePage, 'btn--search-results': !isHomePage })}
+              type='submit'
+              label={isHomePage ? 'Search' : null}
+              iconAfter='search'
+            />
+          </div>
+          <div className={classnames(
+              'input-group__search-controls',
+              { 'input-group__search-controls-results' : !isHomePage })}>
+            <SelectInput
+              className='select__search'
+              hideLabel
+              iconAfter='expand_more'
+              id='category'
+              label='Choose a search category'
+              name='category'
+              onChange={({selectedItem}) => setCategory(selectedItem.value)}
+              options={selectOptions}
+              selectedItem={category || ''}
+            />
+            <CheckBoxInput
+              id='online'
+              name='online'
+              className='checkbox--blue checkbox--online input--outline'
+              checked={online}
+              handleChange={e => setOnline(e.target.checked)}
+              label='Show only results with digital matches'
+            />
+          </div>
         </div>
       </div>
     </form>)

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -1,18 +1,20 @@
 import React, { useEffect, useState } from 'react'
 import Button from '../Button'
 import PropTypes from 'prop-types'
-import { SelectInput, TextInput } from '../Inputs'
+import { CheckBoxInput, SelectInput, TextInput } from '../Inputs'
 import './styles.scss'
 
 const SearchForm = props => {
   var [category, setCategory] = useState(props.category || '')
+  var [online, setOnline] = useState(props.online)
   var [query, setQuery] = useState(props.query)
 
-  /** Sets the search category */
+  /** Sets the search category, query and online checkbox */
   useEffect(() => {
     setCategory(props.category)
+    setOnline(props.online ? true : false)
     setQuery(props.query)
-  }, [props.category, props.query])
+  }, [props.category, props.online, props.query])
 
   const selectOptions = [
     { value: '', label: 'All Types' },
@@ -35,7 +37,13 @@ const SearchForm = props => {
             handleChange={e => setQuery(e.target.value)}
             type='search'
             required
-        />
+          />
+          <Button
+            className='btn--search'
+            type='submit'
+            label='Search'
+            iconBefore='search'
+          />
           <SelectInput
             className='select__search'
             hideLabel
@@ -46,13 +54,15 @@ const SearchForm = props => {
             onChange={({selectedItem}) => setCategory(selectedItem.value)}
             options={selectOptions}
             selectedItem={category || ''}
-        />
-          <Button
-            className='btn--search'
-            type='submit'
-            ariaLabel='Submit search'
-            iconBefore='search'
-        />
+          />
+          <CheckBoxInput
+            id='online'
+            name='online'
+            className='checkbox--blue input--outline'
+            checked={online}
+            handleChange={e => setOnline(e.target.checked)}
+            label='Show only results with digital matches'
+          />
         </div>
       </div>
     </form>)

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -10,6 +10,7 @@ const SearchForm = props => {
   var [online, setOnline] = useState(props.online)
   var [query, setQuery] = useState(props.query)
   const isHomePage = props.className === 'search-form--home'
+  const isMobile = window.innerWidth < 580;
 
   /** Sets the search category, query and online checkbox */
   useEffect(() => {
@@ -44,7 +45,7 @@ const SearchForm = props => {
             <Button
               className={classnames({ 'btn--search': isHomePage, 'btn--search-results': !isHomePage })}
               type='submit'
-              label={isHomePage ? 'Search' : null}
+              label={isHomePage ? (isMobile ? null : 'Search' ) : null}
               iconAfter='search'
             />
           </div>

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -42,8 +42,10 @@ const SearchForm = props => {
             className='btn--search'
             type='submit'
             label='Search'
-            iconBefore='search'
+            iconAfter='search'
           />
+        </div>
+        <div className='input-group__search-controls'>
           <SelectInput
             className='select__search'
             hideLabel
@@ -58,7 +60,7 @@ const SearchForm = props => {
           <CheckBoxInput
             id='online'
             name='online'
-            className='checkbox--blue input--outline'
+            className='checkbox--blue checkbox--online input--outline'
             checked={online}
             handleChange={e => setOnline(e.target.checked)}
             label='Show only results with digital matches'

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -181,6 +181,13 @@
   }
 }
 
+.btn--search-results {
+  @extend .btn--search;
+  padding: 10px 12px;
+  height: 48px;
+  min-width: unset;
+}
+
 .btn--search-more {
   @extend .btn--orange;
   @extend .btn--sm;

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -172,13 +172,15 @@
   border-radius: 0px;
   padding: 18px 20px;
   margin-left: -1px;
-  min-width: 150px;
   border: 1px solid $med-brown;
   &:focus {
     outline: none;
     box-shadow: 0 0 0 1px $pure-white inset;
     background: $med-brown;
     border: 1px solid $med-brown;
+  }
+  @include md-up {
+    min-width: 150px;
   }
 }
 

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -168,17 +168,12 @@
 }
 
 .btn--search {
-  @extend .btn--block;
   @extend .btn--orange;
   border-radius: 0px;
-  height: 62px;
-  width: 66px;
+  padding: 18px 20px;
+  margin-left: -1px;
+  min-width: 150px;
   border: 1px solid $med-brown;
-  & .material-icons {
-    font-size: 36px;
-    line-height: 58px;
-    width: 58px;
-  }
   &:focus { //match .btn--orange hover styles
     outline: none;
     background: $med-brown;

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -174,8 +174,9 @@
   margin-left: -1px;
   min-width: 150px;
   border: 1px solid $med-brown;
-  &:focus { //match .btn--orange hover styles
+  &:focus {
     outline: none;
+    box-shadow: 0 0 0 1px $pure-white inset;
     background: $med-brown;
     border: 1px solid $med-brown;
   }
@@ -184,7 +185,7 @@
 .btn--search-results {
   @extend .btn--search;
   padding: 10px 12px;
-  height: 48px;
+  height: 46px;
   min-width: unset;
 }
 

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -147,9 +147,14 @@ label {
 
 .checkbox--online:not(:checked) + label,
 .checkbox--online:checked + label {
+  font-size: 14px;
   padding: 13px 15px 13px 45px;
-  background: $neutral-sand;
-  min-width: 266px;
+  background: $lighter-gray;
+}
+
+.checkbox--online:checked + label {
+  background: $deep-blue;
+  color: $pure-white;
 }
 
 .checkbox--online:not(:checked) + label:before,
@@ -160,6 +165,9 @@ label {
 
 .checkbox--online:not(:checked) + label:after,
 .checkbox--online:checked + label:after {
+  background-color: $pure-white;
+  border: 1px solid $deep-blue;
+  color: $deep-blue;
   top: 13px;
   left: 15px;
 }

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -48,6 +48,10 @@ label {
   @include visually-hidden;
 }
 
+.input--outline {
+  border: 1px solid;
+}
+
 /* Base for label styling */
 .checkbox:not(:checked),
 .checkbox:checked {
@@ -139,6 +143,26 @@ label {
 
 .checkbox:disabled + label {
   color: $med-gray;
+}
+
+.checkbox--online:not(:checked) + label,
+.checkbox--online:checked + label {
+  padding: 13px 15px 13px 45px;
+  margin-top: 20px;
+  background: $neutral-sand;
+  min-width: 266px;
+}
+
+.checkbox--online:not(:checked) + label:before,
+.checkbox--online:checked + label:before {
+  top: 13px;
+  left: 15px;
+}
+
+.checkbox--online:not(:checked) + label:after,
+.checkbox--online:checked + label:after {
+  top: 13px;
+  left: 15px;
 }
 
 .dp__wrapper {
@@ -277,4 +301,8 @@ label {
       color: $burnt-orange;
     }
   }
+}
+
+.select__search__menu {
+  top: 20px;
 }

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -148,7 +148,6 @@ label {
 .checkbox--online:not(:checked) + label,
 .checkbox--online:checked + label {
   padding: 13px 15px 13px 45px;
-  margin-top: 20px;
   background: $neutral-sand;
   min-width: 266px;
 }
@@ -301,8 +300,4 @@ label {
       color: $burnt-orange;
     }
   }
-}
-
-.select__search__menu {
-  top: 20px;
 }

--- a/src/styles/components/_search-form.scss
+++ b/src/styles/components/_search-form.scss
@@ -11,6 +11,7 @@ input[type=search] {
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  max-width: 1300px;
   margin: 30px 30px 110px 30px;
   @include md-up {
     margin: 59px 75px 190px 75px;
@@ -34,7 +35,9 @@ input[type=search] {
 }
 
 .search-form--results {
-  max-width: 700px;
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .input-group__search {
@@ -43,20 +46,44 @@ input[type=search] {
   width: 100%;
 }
 
+.input-group__search-results {
+  justify-content: flex-start;
+  margin-bottom: 20px;
+  margin-right: 30px;
+  width: 310px;
+  @include lg-up {
+    margin-bottom: 0;
+  }
+}
+
 .input-group__search-controls {
   @extend .input-group__search;
   justify-content: flex-start;
   flex-wrap: wrap;
+  margin-top: 20px;
   @include lg-up {
-    width: calc(100% - 600px);
+    width: calc(100% - 500px);
   }
+}
+
+.input-group__search-controls-results {
+  flex-wrap: nowrap;
+  margin-top: 0;
+  width: 100%;
+  @include lg-up {
+    width: unset;
+  };
 }
 
 .input__search {
   width:100%;
   @include lg-up {
-    width: calc(100% - 750px);
+    width: calc(100% - 650px);
   }
+}
+
+.input__search-results {
+  width: unset;
 }
 
 .input__search input {
@@ -68,18 +95,24 @@ input[type=search] {
   appearance: none
 }
 
+.input__search-results input {
+  height: 48px;
+}
+
+.select__search__wrapper {
+  margin-right: 14px;
+}
+
 .select__search__control {
   display: none;
   font-size: 16px;
   border: 1px solid $orange-gray;
   padding: 13px 15px;
-  margin-right: 14px;
-  margin-top: 20px;
   width: 180px;
   box-sizing: border-box;
   & > .material-icons {
-    right: 29px;
-    top: 33px;
+    right: 15px;
+    top: 13px;
   }
   @include md-up {
     display: block;

--- a/src/styles/components/_search-form.scss
+++ b/src/styles/components/_search-form.scss
@@ -10,6 +10,7 @@ input[type=search] {
 .search-form--home {
   display: flex;
   justify-content: center;
+  flex-wrap: wrap;
   margin: 30px 30px 110px 30px;
   @include md-up {
     margin: 59px 75px 190px 75px;
@@ -38,12 +39,23 @@ input[type=search] {
 
 .input-group__search {
   display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.input-group__search-controls {
+  @extend .input-group__search;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  @include lg-up {
+    width: calc(100% - 600px);
+  }
 }
 
 .input__search {
   width:100%;
   @include lg-up {
-    width: calc(100% - 220px);
+    width: calc(100% - 750px);
   }
 }
 
@@ -59,17 +71,15 @@ input[type=search] {
 .select__search__control {
   display: none;
   font-size: 16px;
-  border-top: 1px solid $dark-gray;
-  border-bottom: 1px solid $dark-gray;
-  border-left: 0;
-  border-right: 0;
-  padding: 16px 18px;
-  height: 62px;
+  border: 1px solid $orange-gray;
+  padding: 13px 15px;
+  margin-right: 14px;
+  margin-top: 20px;
   width: 180px;
   box-sizing: border-box;
   & > .material-icons {
-    right: 23px;
-    top: 20px;
+    right: 29px;
+    top: 33px;
   }
   @include md-up {
     display: block;

--- a/src/styles/components/_search-form.scss
+++ b/src/styles/components/_search-form.scss
@@ -99,7 +99,11 @@ input[type=search] {
 }
 
 .select__search__wrapper {
+  display: none;
   margin-right: 14px;
+  @include md-up {
+    display: block;
+  }
 }
 
 .select__search__control {
@@ -112,9 +116,6 @@ input[type=search] {
   & > .material-icons {
     right: 15px;
     top: 13px;
-  }
-  @include md-up {
-    display: block;
   }
 }
 

--- a/src/styles/components/_search-form.scss
+++ b/src/styles/components/_search-form.scss
@@ -24,7 +24,7 @@ input[type=search] {
 .search-bar {
   width: 100%;
   background-color: $pale-blue;
-  padding: 24px 0px;
+  padding-bottom: 24px;
 }
 
 .results, .search-form--results {
@@ -48,11 +48,10 @@ input[type=search] {
 
 .input-group__search-results {
   justify-content: flex-start;
-  margin-bottom: 20px;
-  margin-right: 30px;
-  width: 460px;
-  @include lg-up {
-    margin-bottom: 0;
+  margin-top: 24px;
+  @include md-up {
+    margin-right: 30px;
+    width: 460px;
   }
 }
 
@@ -68,7 +67,7 @@ input[type=search] {
 
 .input-group__search-controls-results {
   flex-wrap: nowrap;
-  margin-top: 0;
+  margin-top: 24px;
   width: 100%;
   @include lg-up {
     width: unset;

--- a/src/styles/components/_search-form.scss
+++ b/src/styles/components/_search-form.scss
@@ -50,7 +50,7 @@ input[type=search] {
   justify-content: flex-start;
   margin-bottom: 20px;
   margin-right: 30px;
-  width: 310px;
+  width: 460px;
   @include lg-up {
     margin-bottom: 0;
   }
@@ -72,7 +72,7 @@ input[type=search] {
   width: 100%;
   @include lg-up {
     width: unset;
-  };
+  }
 }
 
 .input__search {
@@ -96,7 +96,7 @@ input[type=search] {
 }
 
 .input__search-results input {
-  height: 48px;
+  height: 46px;
 }
 
 .select__search__wrapper {


### PR DESCRIPTION
Removes the digital object checkbox from the "Filter Search" modal, and groups it with the type dropdown.

The styling felt a little messy on this one as I was doing it - would appreciate a second set of eyes on that in particular.

Fixes #217 