### PR TITLE
Scroll focused element into view, improve focus styles

### DIFF
--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -143,6 +143,13 @@ const RecordsDetail = props => {
     props.params && props.params.query ? appendParams('/search', props.params) : '/'
   )
 
+  /** Scrolls a component into view in the records tree **/
+  const scrollFocusedIntoView = uri => {
+    const el = document.getElementById(`accordion__heading-${uri}`);
+    el.focus();
+    el.scrollIntoView({ behavior: 'smooth', block: 'center'});
+  }
+
   /** Parses an item's identifier from its URI */
   const identifier = (
     props.item.uri && props.item.uri.split('/')[props.item.uri.split('/').length - 1]
@@ -154,6 +161,10 @@ const RecordsDetail = props => {
       <a href={searchUrl} className='btn btn--back'>
         <MaterialIcon icon='keyboard_arrow_left'/>Back to Search
       </a>
+      <button className='btn btn--scroll-focused' onClick={() => scrollFocusedIntoView(props.item.uri)}>
+        Locate within collection
+        <MaterialIcon icon='gps_fixed'/>
+      </button>
     </nav>
     <h1 className='records__title'>{props.isItemLoading ? <Skeleton /> : props.item.title }</h1>
     {props.item.type === 'object' &&
@@ -274,6 +285,7 @@ RecordsDetail.propTypes = {
   item: PropTypes.object.isRequired,
   myListCount: PropTypes.number.isRequired,
   params: PropTypes.object.isRequired,
+  scrollFocusedIntoView: PropTypes.func.isRequired,
   toggleInList: PropTypes.func.isRequired,
 }
 

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -157,11 +157,11 @@ const RecordsDetail = props => {
 
   return (
   <div className={classnames('records__detail', {'hidden': props.isContentShown})}>
-    <nav>
+    <nav className='records__nav'>
       <a href={searchUrl} className='btn btn--back'>
         <MaterialIcon icon='keyboard_arrow_left'/>Back to Search
       </a>
-      <button className='btn btn--scroll-focused' onClick={() => scrollFocusedIntoView(props.item.uri)}>
+      <button className='btn btn--sm btn--light-blue btn--scroll-focused' onClick={() => scrollFocusedIntoView(props.item.uri)}>
         Locate within collection
         <MaterialIcon icon='gps_fixed'/>
       </button>
@@ -285,7 +285,6 @@ RecordsDetail.propTypes = {
   item: PropTypes.object.isRequired,
   myListCount: PropTypes.number.isRequired,
   params: PropTypes.object.isRequired,
-  scrollFocusedIntoView: PropTypes.func.isRequired,
   toggleInList: PropTypes.func.isRequired,
 }
 

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -145,9 +145,11 @@ const RecordsDetail = props => {
 
   /** Scrolls a component into view in the records tree **/
   const scrollFocusedIntoView = uri => {
-    const el = document.getElementById(`accordion__heading-${uri}`);
-    el.focus();
-    el.scrollIntoView({ behavior: 'smooth', block: 'center'});
+    const el = document.getElementById(`accordion__heading-${uri}`)
+    if (el) {
+      el.focus()
+      el.scrollIntoView({ behavior: 'smooth', block: 'center'})
+    }
   }
 
   /** Parses an item's identifier from its URI */

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -77,6 +77,17 @@
   }
 }
 
+.btn--light-blue {
+  background: $light-blue;
+  color: $deep-navy;
+  border: 1px solid $light-gray;
+  &:hover, &:focus {
+    background: lighten($light-blue, 5%);
+    border: 1px solid $light-gray;
+    color: $deep-navy;
+  }
+}
+
 .btn--navy {
   background: $deep-navy;
   color: $pure-white;
@@ -142,10 +153,7 @@
 .btn--back {
   @extend .btn--gray;
   @extend .btn--sm;
-  margin-top: 20px;
-  @include md-up  {
-    margin-top: 30px;
-  }
+  margin-bottom: 0;
 }
 
 .btn--back-item {
@@ -163,6 +171,7 @@
 .btn--new-search {
   @extend .btn--back;
   @extend .btn--sm;
+  margin-top: 20px;
   position: absolute;
   margin-left: $gutters-default;
 }
@@ -278,4 +287,10 @@
   @include records-detail-btn;
   @extend .btn--orange;
   box-sizing: border-box;
+}
+
+.btn--scroll-focused {
+  & .material-icons {
+    @include icon-margin-left;
+  }
 }

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -71,18 +71,18 @@
   color: $pure-white;
   border: 1px solid $deep-blue;
   &:hover, &:focus {
-    background: $dark-blue;
+    background: darken($deep-blue, 10%);
     border: 1px solid $dark-blue;
     color: $pure-white; //for links styled as buttons
   }
 }
 
 .btn--light-blue {
-  background: $light-blue;
+  background: $pale-blue;
   color: $deep-navy;
-  border: 1px solid $light-gray;
+  border: 1px solid $light-blue;
   &:hover, &:focus {
-    background: lighten($light-blue, 5%);
+    background: darken($light-blue, 2%);
     border: 1px solid $light-gray;
     color: $deep-navy;
   }
@@ -93,7 +93,7 @@
   color: $pure-white;
   border: 1px solid $deep-navy;
   &:hover, &:focus {
-    background: $deep-blue;
+    background: darken($deep-navy, 10%);
     border: 1px solid $deep-blue;
     color: $off-white;
   }
@@ -104,7 +104,7 @@
   color: $pure-white;
   border: 1px solid $burnt-orange;
   &:hover {
-    background: $med-brown;
+    background: darken($burnt-orange, 10%);
     border: 1px solid $med-brown;
     color: $off-white;
   }
@@ -129,7 +129,7 @@
   color: $med-gray;
   border: 1px solid $light-med-gray;
   &:hover, &:focus {
-    background: $lighter-gray;
+    background: darken($off-white, 5%);
     color: $med-gray;
   }
 }
@@ -139,7 +139,7 @@
   color: $pure-white;
   border: 1px solid $light-med-gray;
   &:hover {
-    background: $orange-gray;
+    background: darken($light-med-gray, 5%);
     color: $pure-white;
   }
 }
@@ -216,9 +216,8 @@
 }
 
 .btn--filter {
+  @extend .btn--light-blue;
   padding: 12px 16px;
-  background: $pale-blue;
-  border: 1px solid $light-blue;
   font-size: 14px;
   text-transform: none;
   letter-spacing: unset;

--- a/src/styles/components/_records-content.scss
+++ b/src/styles/components/_records-content.scss
@@ -138,7 +138,7 @@
     border-top: 1px solid $neutral-sand;
   }
   &:focus-within, &:hover, .active {
-    background: $light-orange-gray;
+    background: $blue-gray;
   }
 }
 

--- a/src/styles/components/_records-content.scss
+++ b/src/styles/components/_records-content.scss
@@ -138,7 +138,7 @@
     border-top: 1px solid $neutral-sand;
   }
   &:focus-within, &:hover, .active {
-    background: $off-white;
+    background: $light-orange-gray;
   }
 }
 

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -25,6 +25,16 @@
   }
 }
 
+.records__nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  @include md-up  {
+    margin-top: 30px;
+  }
+}
+
 .records__title {
   font-family: $sans-serif-stack;
   font-size: 28px;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -12,7 +12,7 @@ $light-orange: #FFE5E5; //modal form error
 
 $deep-navy: #192E49;
 $faded-navy: rgba(25,45,73,0.5);
-$dark-blue: #113768; //button hover
+$dark-blue: #113768; //button border
 $deep-blue: #1A5096;
 $light-blue: #C6D2DE;
 $pale-blue: #EBEFF4;
@@ -22,9 +22,9 @@ $dark-gray: #2F2F2F;
 $med-gray: #5B5B5B;
 $light-med-gray: #A9A9A9; //button border
 $orange-gray: #BCBAB4; //tile border
-$blue-gray: rgba(117,133,154,0.3);
+$blue-gray: rgba(117,133,154,0.3); //records content focus
 $neutral-sand: #E3E1DD;
-$lighter-gray: #EDEDEB; //button hover
+$lighter-gray: #EDEDEB;
 $off-white: #F6F6F4;
 $pure-white: #FFFFFF;
 $pure-black: #000000;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -22,7 +22,7 @@ $dark-gray: #2F2F2F;
 $med-gray: #5B5B5B;
 $light-med-gray: #A9A9A9; //button border
 $orange-gray: #BCBAB4; //tile border
-$light-orange-gray: rgba(117,133,154,0.3);
+$blue-gray: rgba(117,133,154,0.3);
 $neutral-sand: #E3E1DD;
 $lighter-gray: #EDEDEB; //button hover
 $off-white: #F6F6F4;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -22,6 +22,7 @@ $dark-gray: #2F2F2F;
 $med-gray: #5B5B5B;
 $light-med-gray: #A9A9A9; //button border
 $orange-gray: #BCBAB4; //tile border
+$light-orange-gray: rgba(117,133,154,0.3);
 $neutral-sand: #E3E1DD;
 $lighter-gray: #EDEDEB; //button hover
 $off-white: #F6F6F4;


### PR DESCRIPTION
Adds a button to scroll focused element back into view. Also changes color for focused items in tree.

I decided to have the button which scrolls the focused element into view always display, mostly because it's the less complex thing to do. If testing reveals that users can't see the button, then we can look at that as an enhancement.

Fixes #363 