### PR TITLE
Search when user clicks on digital matches filter checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "mirador": "^3.0.0",
     "node-sass": "^4.14.1",
     "pluralize": "^8.0.0",
+    "query-string": "^7.0.0",
     "react": "^16.13.1",
     "react-accessible-dropdown-menu-hook": "^2.1.1",
     "react-aria-live": "^2.0.5",

--- a/src/components/PageAgent/index.js
+++ b/src/components/PageAgent/index.js
@@ -55,7 +55,7 @@ class PageAgent extends Component {
 
   /** Fetches agent data */
   componentDidMount() {
-    const params = queryString.parse(this.props.location.search);
+    const params = queryString.parse(this.props.location.search, {parseBooleans: true});
     this.setState({ params: params })
     axios
       .get(`${process.env.REACT_APP_ARGO_BASEURL}/agents/${this.props.match.params.id}`)

--- a/src/components/PageRecords/index.js
+++ b/src/components/PageRecords/index.js
@@ -36,7 +36,7 @@ class PageRecords extends Component {
       this.setState({ isItemLoading: false });
     }
     const itemUrl = `${process.env.REACT_APP_ARGO_BASEURL}/${this.props.match.params.type}/${this.props.match.params.id}`
-    const params = queryString.parse(this.props.location.search);
+    const params = queryString.parse(this.props.location.search, {parseBooleans: true});
     this.setState({ params: params })
     this.getItemData(itemUrl, params, true)
   };

--- a/src/components/PageSearch/index.js
+++ b/src/components/PageSearch/index.js
@@ -35,7 +35,7 @@ class PageSearch extends Component {
 
   /** Execute search based on params */
   componentDidMount() {
-    let params = queryString.parse(this.props.location.search)
+    let params = queryString.parse(this.props.location.search, {parseBooleans: true})
     params.limit = this.state.pageSize
     this.executeSearch(params)
   };
@@ -126,6 +126,12 @@ class PageSearch extends Component {
     this.executeSearch(params);
   }
 
+  /** Sets online flag when chechbox is checked **/
+  handleOnlineChange = (event) => {
+    var params = { ...this.state.params, online: event.target.checked }
+    this.executeSearch(params)
+  }
+
   /** Sets offset and executes search based on user input */
   handlePageClick = (data) => {
     let offset = Math.ceil(data.selected * this.state.pageSize);
@@ -147,8 +153,6 @@ class PageSearch extends Component {
     this.setState({ facetIsOpen: !this.state.facetIsOpen })
   }
 
-
-
   sortOptions = [
     {value: '', label: 'Sort by relevance'},
     {value: 'title', label: 'Sort by title'},
@@ -166,6 +170,7 @@ class PageSearch extends Component {
           <div className='search-bar'>
             <SearchForm
               className='search-form--results'
+              handleOnlineChange={this.handleOnlineChange}
               query={this.state.params.query}
               online={this.state.params.online}
               category={this.state.params.category} />

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -14,7 +14,6 @@ const SearchForm = props => {
 
   /** Sets the search category, query and online checkbox */
   useEffect(() => {
-    setCategory(props.category)
     setOnline(props.online ? true : false)
     setQuery(props.query)
   }, [props.category, props.online, props.query])
@@ -43,9 +42,9 @@ const SearchForm = props => {
               required
             />
             <Button
-              className={classnames({ 'btn--search': isHomePage, 'btn--search-results': !isHomePage })}
+              className={ classnames({ 'btn--search': isHomePage, 'btn--search-results': !isHomePage })}
               type='submit'
-              label={isHomePage ? (isMobile ? null : 'Search' ) : null}
+              label={isHomePage ? (isMobile ? null : 'Search') : null}
               iconAfter='search'
               ariaLabel='Submit search'
             />
@@ -60,16 +59,16 @@ const SearchForm = props => {
               id='category'
               label='Choose a search category'
               name='category'
-              onChange={({selectedItem}) => setCategory(selectedItem.value)}
-              options={selectOptions}
-              selectedItem={category || ''}
+              onChange={({ selectedItem }) => setCategory(selectedItem.value)}
+              options={ selectOptions }
+              selectedItem={ category || '' }
             />
             <CheckBoxInput
               id='online'
               name='online'
               className='checkbox--blue checkbox--online input--outline'
               checked={online}
-              handleChange={e => setOnline(e.target.checked)}
+              handleChange={e => { isHomePage ? setOnline(e.target.checked) : props.handleOnlineChange(e) }}
               label='Show only results with digital matches'
             />
           </div>
@@ -79,7 +78,8 @@ const SearchForm = props => {
 }
 
 SearchForm.propTypes = {
-  className: PropTypes.string
+  className: PropTypes.string,
+  handleOnlineChange: PropTypes.func
 }
 
 export default SearchForm

--- a/yarn.lock
+++ b/yarn.lock
@@ -5117,6 +5117,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -9700,6 +9705,16 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.0.tgz#aaad2c8d5c6a6d0c6afada877fecbd56af79e609"
+  integrity sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -11178,6 +11193,11 @@ spdy@^4.0.1:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -11293,6 +11313,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Executes a search when users click on the checkbox "button" to filter digital objects on the interior search page. On the home page, clicking on the button does not execute a new search.

I also fixed a bug where querystring parsing was not converting strings into booleans. 

fixes #373 