### PR TITLE
Change border color for light blue button

### DIFF
--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -80,7 +80,7 @@
 .btn--light-blue {
   background: $pale-blue;
   color: $deep-navy;
-  border: 1px solid $light-blue;
+  border: 1px solid $deep-navy;
   &:hover, &:focus {
     background: darken($light-blue, 2%);
     border: 1px solid $light-gray;


### PR DESCRIPTION
Changes the border color for the `btn--light-blue` to `$deep-navy`. Note that this also changes the `Locate in Collection` button.

Fixes #382 