### PR TITLE
Add total results number to facet and a save & close button

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-REACT_APP_ARGO_BASEURL=http://10.0.1.90:8010
+REACT_APP_ARGO_BASEURL=https://api.rockarch.org
 REACT_APP_REQUEST_BROKER_BASEURL=http://rac-vch.ad.rockarchive.org:8001/api
 REACT_APP_LOCALSTORAGE_KEY=DIMESMyList
 REACT_APP_S3_BASEURL=https://iiif.rockarch.org

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-REACT_APP_ARGO_BASEURL=https://api.rockarch.org
+REACT_APP_ARGO_BASEURL=http://10.0.1.90:8010
 REACT_APP_REQUEST_BROKER_BASEURL=http://rac-vch.ad.rockarchive.org:8001/api
 REACT_APP_LOCALSTORAGE_KEY=DIMESMyList
 REACT_APP_S3_BASEURL=https://iiif.rockarch.org

--- a/src/components/ModalSearch/__tests__/ModalSearch.test.js
+++ b/src/components/ModalSearch/__tests__/ModalSearch.test.js
@@ -25,6 +25,7 @@ it('renders props correctly', () => {
       handleDateChange={jest.fn()}
       isOpen
       params={{}}
+      resultsCount={2}
       data={facet}
       toggleModal={jest.fn()} />, container)
   })
@@ -51,6 +52,7 @@ it('handles clicks', () => {
       handleDateChange={handleDateChange}
       isOpen
       params={{}}
+      resultsCount={2}
       data={facet}
       toggleModal={jest.fn()} />, container)
   })

--- a/src/components/ModalSearch/index.js
+++ b/src/components/ModalSearch/index.js
@@ -32,7 +32,9 @@ export const FacetModal = props => {
       }}
       closeTimeoutMS={200} >
       <div className='modal-header--search'>
-        <h2 className='modal-header__title'>{`Filter ${props.resultsCount} Search ${props.resultsCount === 1 ? 'Result': 'Results'}`}</h2>
+        <h2 className='modal-header__title' aria-live='polite' aria-atomic='true'>
+          {`Filter ${props.resultsCount} Search ${props.resultsCount === 1 ? 'Result': 'Results'}`}
+        </h2>
         <button className='modal-header__button' aria-label='Close' onClick={props.toggleModal}>
           <MaterialIcon icon='close' />
         </button>

--- a/src/components/ModalSearch/index.js
+++ b/src/components/ModalSearch/index.js
@@ -32,7 +32,7 @@ export const FacetModal = props => {
       }}
       closeTimeoutMS={200} >
       <div className='modal-header--search'>
-        <h2 className='modal-header__title'>Filter Search Results</h2>
+        <h2 className='modal-header__title'>{`Filter ${props.resultsCount} Search ${props.resultsCount === 1 ? 'Result': 'Results'}`}</h2>
         <button className='modal-header__button' aria-label='Close' onClick={props.toggleModal}>
           <MaterialIcon icon='close' />
         </button>
@@ -83,5 +83,6 @@ FacetModal.propTypes = {
   handleDateChange: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
   params: PropTypes.object.isRequired,
+  resultsCount: PropTypes.number.isRequired,
   toggleModal: PropTypes.func.isRequired
 }

--- a/src/components/ModalSearch/index.js
+++ b/src/components/ModalSearch/index.js
@@ -35,9 +35,11 @@ export const FacetModal = props => {
         <h2 className='modal-header__title' aria-live='polite' aria-atomic='true'>
           {`Filter ${props.resultsCount} Search ${props.resultsCount === 1 ? 'Result': 'Results'}`}
         </h2>
-        <button className='modal-header__button' aria-label='Close' onClick={props.toggleModal}>
-          <MaterialIcon icon='close' />
-        </button>
+        <Button
+          className='btn--blue btn--sm'
+          aria-label='Close'
+          label='Save &amp; Close'
+          handleClick={props.toggleModal} />
       </div>
       <div className='modal-body--search'>
         <Facet title='Date Range'>

--- a/src/components/PageSearch/index.js
+++ b/src/components/PageSearch/index.js
@@ -252,6 +252,7 @@ class PageSearch extends Component {
           toggleModal={this.toggleFacetModal}
           data={this.state.facetData}
           params={this.state.params}
+          resultsCount={this.state.resultsCount}
           handleChange={this.handleFacetChange}
           handleDateChange={this.handleDateFacetChange} />
       </React.Fragment>

--- a/src/styles/components/_modal-search.scss
+++ b/src/styles/components/_modal-search.scss
@@ -20,4 +20,6 @@
   float: left;
   width: 100%;
   box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
 }


### PR DESCRIPTION
Adds the total results number to the Facets title. 

There are a couple of things that I think are maybe not ideal about this approach:
- Clicking on a facet doesn't always change the results count
- Depending on how far you've scrolled down the facet modal, the title text may not be visible
- There's a bit of a disconnect between the number of results (which are collections) and the number of hits (which are the actual matches.

Curious for your thoughts. It may be that we want to do a bit more research to figure out other UI patterns that work for this sort of thing. 

Fixes #387 