### PR TITLE
Set category and query before performing search

### DIFF
--- a/src/components/PageSearch/index.js
+++ b/src/components/PageSearch/index.js
@@ -128,8 +128,13 @@ class PageSearch extends Component {
   }
 
   /** Sets online flag when chechbox is checked **/
-  handleOnlineChange = (event) => {
-    var params = { ...this.state.params, online: event.target.checked }
+  handleOnlineChange = (event, query, category) => {
+    var params = { ...this.state.params, query: query, category: category }
+    if (event.target.checked) {
+      params = { ...params, online: true }
+    } else {
+      delete params.online
+    }
     this.executeSearch(params)
   }
 

--- a/src/components/PageSearch/index.js
+++ b/src/components/PageSearch/index.js
@@ -127,10 +127,11 @@ class PageSearch extends Component {
     this.executeSearch(params);
   }
 
-  /** Sets online flag when chechbox is checked **/
-  handleOnlineChange = (event, query, category) => {
+  /** Executes a new search when search form inputs are changed **/
+  handleSearchFormChange = (category, query, online) => {
     var params = { ...this.state.params, query: query, category: category }
-    if (event.target.checked) {
+    if (online) {
+      console.log(online);
       params = { ...params, online: true }
     } else {
       delete params.online
@@ -176,7 +177,7 @@ class PageSearch extends Component {
           <div className='search-bar'>
             <SearchForm
               className='search-form--results'
-              handleOnlineChange={this.handleOnlineChange}
+              handleSearchFormChange={this.handleSearchFormChange}
               query={this.state.params.query}
               online={this.state.params.online}
               category={this.state.params.category} />

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -15,6 +15,7 @@ const SearchForm = props => {
   /** Sets the search category, query and online checkbox */
   useEffect(() => {
     setOnline(props.online ? true : false)
+    setCategory(props.category || '')
     setQuery(props.query)
   }, [props.category, props.online, props.query])
 
@@ -68,7 +69,7 @@ const SearchForm = props => {
               name='online'
               className='checkbox--blue checkbox--online input--outline'
               checked={online}
-              handleChange={e => { isHomePage ? setOnline(e.target.checked) : props.handleOnlineChange(e) }}
+              handleChange={e => { isHomePage ? setOnline(e.target.checked) : props.handleOnlineChange(e, query, category) }}
               label='Show only results with digital matches'
             />
           </div>

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -60,7 +60,9 @@ const SearchForm = props => {
               id='category'
               label='Choose a search category'
               name='category'
-              onChange={({ selectedItem }) => setCategory(selectedItem.value)}
+              onChange={({ selectedItem }) => {
+                isHomePage ? setCategory(selectedItem.value) : props.handleSearchFormChange(selectedItem.value, query, online)
+              }}
               options={ selectOptions }
               selectedItem={ category || '' }
             />
@@ -69,7 +71,9 @@ const SearchForm = props => {
               name='online'
               className='checkbox--blue checkbox--online input--outline'
               checked={online}
-              handleChange={e => { isHomePage ? setOnline(e.target.checked) : props.handleOnlineChange(e, query, category) }}
+              handleChange={e => {
+                isHomePage ? setOnline(e.target.checked) : props.handleSearchFormChange(category, query, e.target.checked)
+              }}
               label='Show only results with digital matches'
             />
           </div>


### PR DESCRIPTION
Sets the query and category correctly when the "Show only results with digital matches" checkbox is clicked. I also realized there was a bug in the logic for the `online` flag, so I've fixed that.

My only reservation here is that the select doesn't behave in the same way as the checkbox. Maybe I'm overthinking it, but that seems somewhat problematic?

Fixes #386