### PR TITLE
Redo locate in collection and hover/focus styles changes

### DIFF
--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -95,3 +95,6 @@ export const firePageViewEvent = title => {
 
 /** Checks the width of the window to determine if current device is mobile **/
 export const isMobile = window.innerWidth < 580;
+
+/** Checks the width of the window to determine if current device is tablet **/
+export const isTablet = window.innerWidth < 1024;

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -13,7 +13,7 @@ import ListToggleButton from '../ListToggleButton'
 import MaterialIcon from '../MaterialIcon'
 import QueryHighlighter from '../QueryHighlighter'
 import { DetailSkeleton, FoundInItemSkeleton } from '../LoadingSkeleton'
-import { appendParams, dateString, hasAccessOrUse, noteText, noteTextByType } from '../Helpers'
+import { appendParams, dateString, hasAccessOrUse, isTablet, noteText, noteTextByType } from '../Helpers'
 import { isItemSaved } from '../MyListHelpers'
 import classnames from 'classnames'
 import './styles.scss'
@@ -163,10 +163,12 @@ const RecordsDetail = props => {
       <a href={searchUrl} className='btn btn--back'>
         <MaterialIcon icon='keyboard_arrow_left'/>Back to Search
       </a>
-      <button className='btn btn--sm btn--light-blue btn--scroll-focused' onClick={() => scrollFocusedIntoView(props.item.uri)}>
-        Locate within collection
-        <MaterialIcon icon='gps_fixed'/>
-      </button>
+      {isTablet ? null : (
+        <button className='btn btn--sm btn--light-blue btn--scroll-focused' onClick={() => scrollFocusedIntoView(props.item.uri)}>
+          Locate within collection
+          <MaterialIcon icon='gps_fixed'/>
+        </button>
+      )}
     </nav>
     <h1 className='records__title'>{props.isItemLoading ? <Skeleton /> : props.item.title }</h1>
     {props.item.type === 'object' &&

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -143,6 +143,15 @@ const RecordsDetail = props => {
     props.params && props.params.query ? appendParams('/search', props.params) : '/'
   )
 
+  /** Scrolls a component into view in the records tree **/
+  const scrollFocusedIntoView = uri => {
+    const el = document.getElementById(`accordion__heading-${uri}`)
+    if (el) {
+      el.focus()
+      el.scrollIntoView({ behavior: 'smooth', block: 'center'})
+    }
+  }
+
   /** Parses an item's identifier from its URI */
   const identifier = (
     props.item.uri && props.item.uri.split('/')[props.item.uri.split('/').length - 1]
@@ -150,10 +159,14 @@ const RecordsDetail = props => {
 
   return (
   <div className={classnames('records__detail', {'hidden': props.isContentShown})}>
-    <nav>
+    <nav className='records__nav'>
       <a href={searchUrl} className='btn btn--back'>
         <MaterialIcon icon='keyboard_arrow_left'/>Back to Search
       </a>
+      <button className='btn btn--sm btn--light-blue btn--scroll-focused' onClick={() => scrollFocusedIntoView(props.item.uri)}>
+        Locate within collection
+        <MaterialIcon icon='gps_fixed'/>
+      </button>
     </nav>
     <h1 className='records__title'>{props.isItemLoading ? <Skeleton /> : props.item.title }</h1>
     {props.item.type === 'object' &&

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -71,7 +71,7 @@
   color: $pure-white;
   border: 1px solid $deep-blue;
   &:hover, &:focus {
-    background: $dark-blue;
+    background: darken($deep-blue, 10%);
     border: 1px solid $dark-blue;
     color: $pure-white; //for links styled as buttons
   }
@@ -93,7 +93,7 @@
   color: $pure-white;
   border: 1px solid $deep-navy;
   &:hover, &:focus {
-    background: $deep-blue;
+    background: darken($deep-blue, 10%);
     border: 1px solid $deep-blue;
     color: $off-white;
   }
@@ -104,7 +104,7 @@
   color: $pure-white;
   border: 1px solid $burnt-orange;
   &:hover {
-    background: $med-brown;
+    background: darken($burnt-orange, 10%);
     border: 1px solid $med-brown;
     color: $off-white;
   }
@@ -129,7 +129,7 @@
   color: $med-gray;
   border: 1px solid $light-med-gray;
   &:hover, &:focus {
-    background: $lighter-gray;
+    background: darken($off-white, 5%);
     color: $med-gray;
   }
 }
@@ -139,7 +139,7 @@
   color: $pure-white;
   border: 1px solid $light-med-gray;
   &:hover {
-    background: $orange-gray;
+    background: darken($light-med-gray, 5%);
     color: $pure-white;
   }
 }
@@ -148,16 +148,18 @@
   background: $pure-black;
   color: $pure-white;
   border: 1px solid $pure-white;
+  &:hover, &:focus {
+    color: $light-med-gray;
+  }
+  &:focus {
+    outline: solid 1px $light-med-gray;
+  }
 }
 
 .btn--back {
   @extend .btn--gray;
   @extend .btn--sm;
   margin-bottom: 0;
-  margin-top: 20px;
-  @include md-up  {
-    margin-top: 30px;
-  }
 }
 
 .btn--back-item {
@@ -175,6 +177,7 @@
 .btn--new-search {
   @extend .btn--back;
   @extend .btn--sm;
+  margin-top:20px;
   position: absolute;
   margin-left: $gutters-default;
 }
@@ -224,9 +227,8 @@
 }
 
 .btn--filter {
+  @extend .btn--light-blue;
   padding: 12px 16px;
-  background: $pale-blue;
-  border: 1px solid $light-blue;
   font-size: 14px;
   text-transform: none;
   letter-spacing: unset;
@@ -295,4 +297,10 @@
   @include records-detail-btn;
   @extend .btn--orange;
   box-sizing: border-box;
+}
+
+.btn--scroll-focused {
+  & .material-icons {
+    @include icon-margin-left;
+  }
 }

--- a/src/styles/components/_records-content.scss
+++ b/src/styles/components/_records-content.scss
@@ -138,7 +138,7 @@
     border-top: 1px solid $neutral-sand;
   }
   &:focus-within, &:hover, .active {
-    background: $off-white;
+    background: $blue-gray;
   }
 }
 

--- a/src/styles/components/_records-detail.scss
+++ b/src/styles/components/_records-detail.scss
@@ -25,6 +25,16 @@
   }
 }
 
+.records__nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  @include md-up  {
+    margin-top: 30px;
+  }
+}
+
 .records__title {
   font-family: $sans-serif-stack;
   font-size: 28px;

--- a/src/styles/variables/_vars.scss
+++ b/src/styles/variables/_vars.scss
@@ -12,7 +12,7 @@ $light-orange: #FFE5E5; //modal form error
 
 $deep-navy: #192E49;
 $faded-navy: rgba(25,45,73,0.5);
-$dark-blue: #113768; //button hover
+$dark-blue: #113768; //button border
 $deep-blue: #1A5096;
 $light-blue: #C6D2DE;
 $pale-blue: #EBEFF4;
@@ -22,8 +22,9 @@ $dark-gray: #2F2F2F;
 $med-gray: #5B5B5B;
 $light-med-gray: #A9A9A9; //button border
 $orange-gray: #BCBAB4; //tile border
+$blue-gray: rgba(117,133,154,0.3); //records content focus
 $neutral-sand: #E3E1DD;
-$lighter-gray: #EDEDEB; //button hover
+$lighter-gray: #EDEDEB;
 $off-white: #F6F6F4;
 $pure-white: #FFFFFF;
 $pure-black: #000000;


### PR DESCRIPTION
When resolving merge errors, I mistakenly reverted the change which added the "Locate in Collection" button and improved the focus styles in container lists. I'm redoing this change here, but this should be reviewed to make sure I didn't bork something else in the process.