### PR TITLE
Updates pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-highlight-words": "^0.17.0",
     "react-loading-skeleton": "^3.0.1",
     "react-modal": "^3.11.2",
-    "react-paginate": "^7.1.3",
+    "react-paginate": "^8.0.0",
     "react-router-dom": "^5.2.1",
     "react-scripts": "4.0.3",
     "sass": "^1.42.1"

--- a/src/components/ModalSavedItem/__tests__/ModalSavedItem.test.js
+++ b/src/components/ModalSavedItem/__tests__/ModalSavedItem.test.js
@@ -1,21 +1,43 @@
 import React from 'react'
-import { render } from 'react-dom'
+import axios from 'axios'
+import { render, unmountComponentAtNode } from 'react-dom'
 import { act } from 'react-dom/test-utils'
 import {ModalSavedItemList} from '..'
 
 import { checkedList } from '../../../__fixtures__/checkedList'
 import { resolvedList } from '../../../__fixtures__/resolvedList'
 
+
+let container = null
+beforeEach(() => {
+  container = document.createElement('div')
+  container.setAttribute('id', 'root')
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  unmountComponentAtNode(container)
+  container.remove()
+  container = null
+})
+
+jest.mock('axios')
+
 it('renders props correctly', async () => {
-  const div = document.createElement('div')
-  document.body.appendChild(div)
+  axios.post.mockImplementation((url) => {
+    if (url.includes('parse')) {
+      return Promise.resolve({data: {}})
+    } else {
+      return Promise.reject(new Error('not found'))
+    }
+  })
 
   await act(async () => {
     render(<ModalSavedItemList
       items={resolvedList}
       ignoreRestrictions={true}
       handleChange={jest.fn()}
-      setSubmit={jest.fn()} />, div)
+      setSubmit={jest.fn()} />, container)
   })
 
   await act(async () => {
@@ -32,7 +54,7 @@ it('renders props correctly', async () => {
       items={checkedList}
       ignoreRestrictions={true}
       handleChange={jest.fn()}
-      setSubmit={jest.fn()} />, div)
+      setSubmit={jest.fn()} />, container)
   })
 
   await act(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9981,10 +9981,10 @@ react-mosaic-component@^4.0.1:
     react-dnd-touch-backend "^10.0.2"
     uuid "^3.3.2"
 
-react-paginate@^7.1.3:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/react-paginate/-/react-paginate-7.1.5.tgz#fac437f67fbeb5bfa688a175142839d94240a58b"
-  integrity sha512-CpyWSwsIIsFhWAQvmXDWuEl+yzfzisgvsUoZTj2IR1mFvm9oPTmeNBFc1wg8/i6ASmETeOmOnc78/U/MXyjd0w==
+react-paginate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-paginate/-/react-paginate-8.0.0.tgz#b03b4ec221bffd8ecb16dd4c1295c33f8c6fd3df"
+  integrity sha512-l5uNYWqVIhFBljQoyLuMnZ8ykCdoTz6aYfg9+fUdtWy/H9rELBgVBPEA99jVpTsBxqAxXKBZ/sdDrdN4b0hsvg==
   dependencies:
     prop-types "^15.6.1"
 


### PR DESCRIPTION
Updates to the next major version of `react-pagination`. There appear to be some minor differences in HTML structure:
- tabindex is -1 instead of 0 on pagination buttons
- some additional rel attributes on pagination buttons

Asking for a review in case any of these are dealbreakers for assistive technologies.

Release notes: https://github.com/AdeleD/react-paginate/releases/tag/v8.0.0