### PR TITLE
Uses ResizeObserver to trigger minimap render on page resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-paginate": "^8.0.1",
     "react-router-dom": "^5.2.1",
     "react-scripts": "5.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "sass": "^1.44.2",
     "url": "^0.11.0"
   },

--- a/src/components/Hooks.js
+++ b/src/components/Hooks.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
+import ResizeObserver from 'resize-observer-polyfill'
 
 // Returns a boolean indicating if an element is visible on screen
 export function useOnScreen(ref) {

--- a/src/components/Hooks.js
+++ b/src/components/Hooks.js
@@ -1,5 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
 
+// Returns a boolean indicating if an element is visible on screen
 export function useOnScreen(ref) {
 
   const [isIntersecting, setIntersecting] = useState(false)
@@ -16,3 +18,35 @@ export function useOnScreen(ref) {
   }, [ref])
   return isIntersecting
 }
+
+// Executes a callback when a ref is resized
+export const useResizeObserver = ({ callback, element }) => {
+
+  const current = element && element.current;
+  const observer = useRef(null);
+
+  useEffect(() => {
+      const currentElement = element.current
+      if (observer.current) {
+        observer.current.observe(currentElement)
+      }
+      observer.current = new ResizeObserver(callback)
+      observe()
+      return () => {
+        // Remove the observer as soon as the component is unmounted
+        observer.current.unobserve(currentElement)
+      }
+  }, [current])
+
+  const observe = () => {
+    if (element && element.current && observer.current) {
+      observer.current.observe(element.current)
+    }
+  }
+
+}
+
+useResizeObserver.propTypes = {
+  element: PropTypes.object,
+  callback: PropTypes.func,
+};

--- a/src/components/Minimap/index.js
+++ b/src/components/Minimap/index.js
@@ -1,8 +1,8 @@
-import React, { useCallback, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { appendParams } from '../Helpers'
-import { MinimapSkeleton } from '../LoadingSkeleton'
+import { useResizeObserver } from '../Hooks'
 import './styles.scss'
 
 /**
@@ -15,14 +15,16 @@ const Minimap = ({ data, isLoading, params, rowCount=4 }) => {
   const [containerHeight, setContainerHeight] = useState(0)
   const [containerWidth, setContainerWidth] = useState(0)
 
-  const minimapContainer = useCallback(node => { /* 1 */
-    if (node !== null) {
-      setTimeout(() => {
-        setContainerHeight(node.getBoundingClientRect().height)
-        setContainerWidth(node.getBoundingClientRect().width)
-      }, 300)
+  const minimapContainer = useRef(null)
+
+  const setDimensions = () => {
+    if (minimapContainer.current !== null) {
+      setContainerHeight(minimapContainer.current.getBoundingClientRect().height)
+      setContainerWidth(minimapContainer.current.getBoundingClientRect().width)
     }
-  }, []);
+  }
+
+  useResizeObserver({ callback: setDimensions, element: minimapContainer })
 
   const boxWidthHeight = containerWidth / rowCount
   const totalBoxes = containerHeight && boxWidthHeight ? parseInt(parseInt(containerHeight) / boxWidthHeight) * rowCount : 0

--- a/src/styles/components/_minimap.scss
+++ b/src/styles/components/_minimap.scss
@@ -65,7 +65,7 @@ $grid-col-count: 20;
   background: $color;
   color: $color;
   display: flex; /* 1 */
-  justify-content: right; /* 1 */
+  justify-content: flex-end; /* 1 */
   text-decoration: none;
   margin: 0; // added
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8118,6 +8118,11 @@ reselect@^4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
   integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"


### PR DESCRIPTION
Uses the ResizeObserver API to watch the Minimap container and re-render the minimap when the container size changes. Fixes #458 