### PR TITLE
Update link to API docs

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -39,7 +39,7 @@ const Footer = () => (
           <div className='footer-secondary__data'>
             <ul className='footer-secondary__list'>
               <li className='footer-secondary__list-item'>
-                <a className='footer-secondary__link' href='https://docs.rockarch.org/argo/'>Collections data API</a>
+                <a className='footer-secondary__link' href='https://docs.rockarch.org/argo-docs/'>Collections data API</a>
               </li>
               <li className='footer-secondary__list-item'>
                 <a className='footer-secondary__link' href='https://github.com/RockefellerArchiveCenter/data/'>Bulk data download</a>


### PR DESCRIPTION
Now that argo has its own repository for documentation, the URL has changed and needs to be updated. Merge only after the Docs Site moves to new deployment.