### PR TITLE
Improve display of sources, convert agent page subheaders to h3

### DIFF
--- a/src/components/AgentAttribute/__tests__/AgentAttribute.test.js
+++ b/src/components/AgentAttribute/__tests__/AgentAttribute.test.js
@@ -2,10 +2,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import AgentAttributeList from '..'
 
-const items = [
-  {'label': 'foo', 'value': 'foobar', 'note': true},
-  {'label': 'bar', 'value': 'barfoo', 'note': false}
-]
+const items = {'Positions Held': 'foo', 'Date of Birth': 'bar', 'Date of Dath': 'baz'}
 
 it('renders without crashing', () => {
   const div = document.createElement('div')

--- a/src/components/AgentAttribute/index.js
+++ b/src/components/AgentAttribute/index.js
@@ -4,7 +4,7 @@ import './styles.scss'
 
 const AgentAttribute = ({ label, value }) => (
   <div className={'agent-attribute'}>
-    <p className='agent-attribute__label'>{label}</p>
+    <h3 className='agent-attribute__label'>{label}</h3>
     <p className='agent-attribute__value'>{value}</p>
   </div>)
 

--- a/src/components/PageAgent/index.js
+++ b/src/components/PageAgent/index.js
@@ -16,11 +16,11 @@ import './styles.scss'
 const AgentNote = ({ source, text }) => (
   text ?
   (<div className={'agent__note'}>
-    <p className='agent-note__label'>Description</p>
+    <h3 className='agent-note__label'>Description</h3>
     <p className='agent-note__value'>
       {text}
-      { source ? (<span className='agent-note__source'>(Source: {source})</span>) : null }
     </p>
+    <p className='agent-note__source'>{ source ? `Source: ${source}` : `Source: Rockefeller Archive Center` }</p>
   </div>) : (null)
 )
 

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -296,7 +296,7 @@ small {
   color: $dark-gray;
 }
 
-.agent-attribute__value, .agent-note__value {
+.agent-attribute__value, .agent-note__value, .agent-note__source {
   font-family: $sans-serif-stack;
   font-size: 16px;
   color: $dark-gray;

--- a/src/styles/components/_agent-attribute.scss
+++ b/src/styles/components/_agent-attribute.scss
@@ -22,7 +22,3 @@
 .agent-attribute__value, .agent-note__value {
   white-space: pre-line;
 }
-
-.agent-note__source {
-  margin-left: 5px;
-}


### PR DESCRIPTION
Wraps sources of agent notes in their own paragraph tag, and converts headings on agent attributes and notes to `h3`s. Some minor updates to styles and tests are also included.

Fixes #507 