### PR TITLE
Use agent name as query

### DIFF
--- a/src/components/PageAgent/index.js
+++ b/src/components/PageAgent/index.js
@@ -31,7 +31,7 @@ const AgentRelatedCollections = ({ agentTitle, collections, params }) => (
     <TileList
       hideHitCount
       items={collections}
-      params={params}
+      params={{...params, query: agentTitle}}
       tileClassName='tile--related-collections'/>
     { collections.length === 6 ?
       (<a href={`/search?query=${agentTitle}&category=collection`} className='btn btn--search-more'>Search More Related Collections</a>) :

--- a/src/components/PageAgent/index.js
+++ b/src/components/PageAgent/index.js
@@ -27,7 +27,7 @@ const AgentNote = ({ source, text }) => (
 const AgentRelatedCollections = ({ agentTitle, collections, params }) => (
   collections.length ?
   (<div className='agent__related'>
-    <h2 className='agent__section-title'>Related Collections</h2>
+    <h2 className='agent__section-title'>Collections Related to {agentTitle}</h2>
     <TileList
       hideHitCount
       items={collections}


### PR DESCRIPTION
Uses the agent name as a query for related collections, as opposed to whatever query string brought a user to the agent page. Also adds the agent name to he header for related collections so it's clear what the collections are related to.

Not a full solution, but towards one for #469 