### PR TITLE
Improve footer layout

### DIFF
--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -64,7 +64,7 @@
     margin-left: 0px;
   }
   @include lg-up {
-    @include grid-column(3);
+    @include grid-column(4);
     float: right;
     text-align: right;
     // margin-right: 40px;

--- a/src/styles/components/_social-icons.scss
+++ b/src/styles/components/_social-icons.scss
@@ -3,7 +3,7 @@
 .rac-social-icons {
   @include lg-up {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: right;
   }
 }
 
@@ -11,6 +11,7 @@
   display: inline-block;
   height: 30px;
   width: 40px;
+  margin-right: 15px;
   text-align: center;
   vertical-align: middle;
   pointer-events: visibleFill;


### PR DESCRIPTION
Footer links and text are wider than their container width, so this fixes the issue of content going onto a second line in the footer.