### PR TITLE
Replace Google Analytics with Matomo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,19 +29,16 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>DIMES: Online Collections and Catalog of Rockefeller Archive Center</title>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-M7TSVRS');</script>
-  <!-- End Google Tag Manager -->
+<!-- Matomo Tag Manager -->
+<script>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.async=true; g.src='https://cdn.matomo.cloud/rockarch.matomo.cloud/container_wRUBz58c.js'; s.parentNode.insertBefore(g,s);
+</script>
+<!-- End Matomo Tag Manager -->
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M7TSVRS"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -73,7 +73,7 @@ export const truncateString = (text, maxLength) => {
   }
 }
 
-/** Sends a custom pageview event to Google Tag Manager.
+/** Sends a custom pageview event to Matomo Tag Manager.
 * This allows us to ensure that the correct page titles are sent.  */
 var done = false
 var prevTitle = ''
@@ -83,7 +83,7 @@ export const firePageViewEvent = title => {
   }
   if (title && !done) {
     if (window && window.dataLayer) {
-      let dataLayer = window.dataLayer || []
+      let dataLayer = window._mtm || []
       dataLayer.push({
         'event': 'reactPageViewEvent'
       })


### PR DESCRIPTION
fix #552 
Replace google analytics tracking code with Matomo and remove Google Analytics (noscript).

Also updates the custom page view trigger to push to the Matomo datalayer to ensure the correct page titles are sent.