### PR TITLE
Debug reactPageViewEvent for Matomo

### DIFF
--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -82,11 +82,11 @@ export const firePageViewEvent = title => {
     done = false
   }
   if (title && !done) {
-    if (window && window.dataLayer) {
-      let dataLayer = window._mtm || []
+    if (window && window._mtm) {
+      let dataLayer = window._mtm || [];
       dataLayer.push({
         'event': 'reactPageViewEvent'
-      })
+      });
       done = true
       prevTitle = title
     }


### PR DESCRIPTION
Fixes issue #563 

Debugs the custom pageview event helper to work with Matomo: window.dataLayer referenced Google's datalayer when it should have been pointing to Matomo.

I tested this in Matomo's Tag Manager preview and it appears to be working and sending the correct page titles as expected.

@helrond , what is line 85 accomplishing in `Helpers.js`? Trying to make sure I understand all the elements here.