### PR TITLE
Dynamically set `isDesktop` and `isMobile` attributes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { LiveAnnouncer } from 'react-aria-live';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Footer from './components/Footer';
@@ -12,9 +12,24 @@ import PageMyList from './components/PageMyList';
 import PageSearch from './components/PageSearch';
 import PageNotFound from './components/PageNotFound';
 import { fetchMyList, isItemSaved, removeItem, saveItem, saveMyList } from './components/MyListHelpers';
+import { useResizeObserver } from './components/Hooks';
 
 const App = () => {
+  const desktopSize = 1024
+  const mobileSize = 580
   const [myListCount, setMyListCount] = useState(0)
+  const [isDesktop, setIsDesktop] = useState()
+  const [isMobile, setIsMobile] = useState()
+  const mainWrapper = useRef(null)
+
+  const updateSizes = () => {
+    setTimeout(() => {
+      setIsDesktop(window.innerWidth >= desktopSize)
+      setIsMobile(window.innerWidth < mobileSize)
+    })
+  }
+
+  useResizeObserver({ callback: updateSizes, element: mainWrapper })
 
   const countMyList = data => {
     var list = data ? data : fetchMyList()
@@ -41,15 +56,15 @@ const App = () => {
     <SkipLink />
     <Header myListCount={myListCount} />
     <main id='main' role='main'>
-      <div className='wrapper'>
+      <div className='wrapper' ref={mainWrapper}>
         <BrowserRouter>
           <Routes>
             <Route path='/list' element={<PageMyList removeAllListItems={removeAllListItems} toggleInList={toggleInList} />} />
             <Route path='/search' element={<PageSearch />} />
             <Route path='/:type/:id/view' element={<PageDigitalObject />} />
-            <Route path='/:type/:id' element={<PageRecords myListCount={myListCount} toggleInList={toggleInList} />} />
+            <Route path='/:type/:id' element={<PageRecords myListCount={myListCount} toggleInList={toggleInList} isDesktop={isDesktop} isMobile={isMobile} />} />
             <Route path='/agents/:id' element={<PageAgent />} />
-            <Route exact path='/' element={<PageHome />} />
+            <Route exact path='/' element={<PageHome isMobile={isMobile} />} />
             <Route path='*' element={<PageNotFound />} />
           </Routes>
         </BrowserRouter>

--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -1,5 +1,4 @@
 import queryString from 'query-string'
-import { useResizeObserver } from './Hooks'
 
 /** Returns a string from a date object or string */
 export const dateString = dates => {
@@ -93,9 +92,3 @@ export const firePageViewEvent = title => {
     }
   }
 }
-
-/** Checks the width of the window to determine if current device is mobile **/
-export const mobileSize = 580;
-
-/** Checks the width of the window to determine if current device is tablet **/
-export const desktopSize = 1024;

--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -1,4 +1,5 @@
 import queryString from 'query-string'
+import { useResizeObserver } from './Hooks'
 
 /** Returns a string from a date object or string */
 export const dateString = dates => {
@@ -94,10 +95,7 @@ export const firePageViewEvent = title => {
 }
 
 /** Checks the width of the window to determine if current device is mobile **/
-export const isMobile = window.innerWidth < 580;
+export const mobileSize = 580;
 
 /** Checks the width of the window to determine if current device is tablet **/
-export const isTablet = window.innerWidth < 1024;
-
-/** Checks the width of the window to determine if current device is tablet **/
-export const isDesktop = window.innerWidth >= 1024;
+export const desktopSize = 1024;

--- a/src/components/Hooks.js
+++ b/src/components/Hooks.js
@@ -31,7 +31,15 @@ export const useResizeObserver = ({ callback, element }) => {
       if (observer.current) {
         observer.current.observe(currentElement)
       }
-      observer.current = new ResizeObserver(callback)
+      observer.current = new ResizeObserver(entries => {
+        window.requestAnimationFrame(() => {
+          if (!Array.isArray(entries) || !entries.length) {
+            return;
+          }
+          callback()
+        });
+        
+      })
       observe()
       return () => {
         // Remove the observer as soon as the component is unmounted

--- a/src/components/PageDigitalObject/index.js
+++ b/src/components/PageDigitalObject/index.js
@@ -4,10 +4,10 @@ import { useParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
 import MaterialIcon from '../MaterialIcon'
 import Viewer from '../Viewer'
-import { firePageViewEvent, isMobile } from '../Helpers'
+import { firePageViewEvent } from '../Helpers'
 import './styles.scss'
 
-const PageDigitalObject = () => {
+const PageDigitalObject = ({isMobile}) => {
 
   const [itemTitle, setItemTitle] = useState("")
   const { id, type } = useParams()

--- a/src/components/PageHome/index.js
+++ b/src/components/PageHome/index.js
@@ -5,7 +5,7 @@ import SearchForm from '../SearchForm';
 import { firePageViewEvent } from '../Helpers';
 import './styles.scss';
 
-const PageHome = () => (
+const PageHome = ({isMobile}) => (
   <>
     <Helmet
       onChangeClientState={(newState) => firePageViewEvent(newState.title)} >
@@ -13,7 +13,7 @@ const PageHome = () => (
     </Helmet>
     <div className='container--full-width home'>
       <Hero />
-      <SearchForm className='search-form--home'/>
+      <SearchForm className='search-form--home' isMobile={isMobile}/>
     </div>
   </>
 )

--- a/src/components/PageRecords/index.js
+++ b/src/components/PageRecords/index.js
@@ -14,9 +14,9 @@ import { ModalMinimap, ModalMinimapInfo } from '../ModalMinimap'
 import RecordsContent from '../RecordsContent'
 import RecordsDetail from '../RecordsDetail'
 import PageNotFound from '../PageNotFound'
-import { appendParams, firePageViewEvent, formatBytes, isDesktop } from '../Helpers'
+import { appendParams, firePageViewEvent, formatBytes } from '../Helpers'
 
-const PageRecords = ({ myListCount, toggleInList }) => {
+const PageRecords = ({ isDesktop, isMobile, myListCount, toggleInList }) => {
 
   const [ancestors, setAncestors] = useState({})
   const [backendError, setBackendError] = useState({})
@@ -214,6 +214,7 @@ const PageRecords = ({ myListCount, toggleInList }) => {
           downloadSize={downloadSize}
           isAncestorsLoading={isAncestorsLoading}
           isContentShown={isContentShown}
+          isDesktop={isDesktop}
           isItemLoading={isItemLoading}
           item={item}
           myListCount={myListCount}
@@ -232,6 +233,7 @@ const PageRecords = ({ myListCount, toggleInList }) => {
           children={children}
           collection={parseCollection()}
           isContentShown={isContentShown}
+          isMobile={isMobile}
           myListCount={myListCount}
           offsetAfter={item.offset + 1}
           offsetBefore={item.offset}

--- a/src/components/RecordsContent/index.js
+++ b/src/components/RecordsContent/index.js
@@ -12,7 +12,7 @@ import { Badge } from '../Badge'
 import ListToggleButton from '../ListToggleButton'
 import MaterialIcon from '../MaterialIcon'
 import QueryHighlighter from '../QueryHighlighter'
-import { appendParams, dateString, isMobile, formatMatchString, truncateString} from '../Helpers'
+import { appendParams, dateString, formatMatchString, truncateString} from '../Helpers'
 import { useOnScreen } from '../Hooks'
 import { isItemSaved } from '../MyListHelpers'
 import { RecordsChildSkeleton } from '../LoadingSkeleton'
@@ -227,13 +227,13 @@ export const RecordsChild = props => {
       <div className='child__buttons'>
         {item.online ? (
           <a className='btn btn-launch--content'
-             href={`${item.uri}/view`}>{isMobile? 'View' : 'View Online'}
+             href={`${item.uri}/view`}>{props.isMobile? 'View' : 'View Online'}
              <MaterialIcon icon='visibility' /></a>) :
           (null)
         }
         <ListToggleButton
           className='btn-add--content'
-          isMobile={isMobile}
+          isMobile={props.isMobile}
           isSaved={isSaved}
           item={props.item}
           toggleSaved={toggleSaved} />

--- a/src/components/RecordsDetail/index.js
+++ b/src/components/RecordsDetail/index.js
@@ -16,7 +16,7 @@ import ListToggleButton from '../ListToggleButton'
 import MaterialIcon from '../MaterialIcon'
 import QueryHighlighter from '../QueryHighlighter'
 import { DetailSkeleton, FoundInItemSkeleton } from '../LoadingSkeleton'
-import { appendParams, dateString, hasAccessOrUse, isDesktop, noteText, noteTextByType } from '../Helpers'
+import { appendParams, dateString, hasAccessOrUse, noteText, noteTextByType } from '../Helpers'
 import { isItemSaved } from '../MyListHelpers'
 import './styles.scss'
 
@@ -152,7 +152,7 @@ const RecordsDetail = props => {
 
   return (
   <div className={classnames('records__detail', {'hidden': props.isContentShown})}>
-    {isDesktop ? <Button
+    {props.isDesktop ? <Button
       type='button'
       className='btn--sm btn--transparent btn--minimap-info'
       handleClick={props.toggleMinimapModal}

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -3,7 +3,6 @@ import classnames from 'classnames'
 import Button from '../Button'
 import PropTypes from 'prop-types'
 import { CheckBoxInput, SelectInput, TextInput } from '../Inputs'
-import { isMobile } from '../Helpers'
 import './styles.scss'
 
 const SearchForm = props => {
@@ -45,7 +44,7 @@ const SearchForm = props => {
             <Button
               className={ classnames({ 'btn--search': isHomePage, 'btn--search-results': !isHomePage })}
               type='submit'
-              label={isHomePage ? (isMobile ? null : 'Search') : null}
+              label={isHomePage ? (props.isMobile ? null : 'Search') : null}
               iconAfter='search'
               ariaLabel='Submit search'
             />


### PR DESCRIPTION
Uses a `ResizeObserver` at the top level of the app and passes down `isDesktop` and `isMobile` attributes to the rest of the app so these values are set dynamically. fixes #589 