### PR TITLE
Improves setting of source for narrative agent notes

### DIFF
--- a/src/components/PageAgent/index.js
+++ b/src/components/PageAgent/index.js
@@ -78,7 +78,7 @@ const PageAgent = () => {
   const [collections, setCollections] = useState([])
   const [attributes, setAttributes] = useState({})
   const [narrativeDescription, setNarrativeDescription] = useState('')
-  const [narrativeDescriptionSource, setNarrativeDescriptionSource] = useState('')
+  const [narrativeDescriptionSource, setNarrativeDescriptionSource] = useState(null)
   const [wikidata, setWikidata] = useState({})
   const [params, setParams] = useState({})
   const { id } = useParams()


### PR DESCRIPTION
Sets narrativeDescriptionSource to null rather than empty string. fixes #686 