### PR TITLE
Removes translation of name attributes in forms

### DIFF
--- a/src/components/ModalMyList/index.js
+++ b/src/components/ModalMyList/index.js
@@ -432,9 +432,7 @@ export const ReadingRoomRequestModal = props => {
           <SubmitListInput submitList={props.submitList} />
           <ErrorMessage
             id='items-error'
-            name={t({
-              message: 'items'
-            })}
+            name='items'
             component='div'
             className='input__error' />
           {!!process.env.REACT_APP_ENABLE_READING_ROOM_SELECT && <ReadingRoomSelect readingRooms={aeonReadingRooms} />}
@@ -449,25 +447,18 @@ export const ReadingRoomRequestModal = props => {
               comment: 'helptext for RAC staff message',
               message: '255 characters maximum'
             })}
-            name={t({
-              comment: 'Name for RAC staff message Form',
-              message: 'questions'
-            })}
+            name='questions'
             maxLength={255}
             component='textarea'
             rows={5} />
           <div className='form-group mx-0'>
             <Field
               component={Captcha}
-              name={t({
-                message: 'recaptcha'
-              })}
+              name='recaptcha'
               handleCaptchaChange={(response) => setFieldValue('recaptcha', response)} />
             <ErrorMessage
               id='recaptcha-error'
-              name={t({
-                message: 'recaptcha'
-              })}
+              name='recaptcha'
               component='div'
               className='input__error' />
           </div>
@@ -578,9 +569,7 @@ export const DuplicationRequestModal = props => (
             <SubmitListInput submitList={props.submitList} />
             <ErrorMessage
               id='items-error'
-                name={t({
-                  message: 'items'
-                })}
+              name='items'
               component='div'
               className='input__error' />
             <FormGroup
@@ -598,10 +587,7 @@ export const DuplicationRequestModal = props => (
                     })}>
                   fee schedule
                 </a>.</Trans>}
-                name={t({
-                  comment: 'Name for duplication request form costs',
-                  message: 'costs'
-                })}
+              name='costs'
               type='checkbox'
               required={true}
               errors={errors}
@@ -615,9 +601,7 @@ export const DuplicationRequestModal = props => (
                 handleCaptchaChange={(response) => setFieldValue('recaptcha', response)} />
               <ErrorMessage
                 id='captcha-error'
-                  name={t({
-                    message: 'recaptcha'
-                  })}
+                name='recaptcha'
                 component='div'
                 className='input__error' />
             </div>

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {Einführung in die Minimap}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {Anfordern {1} Element} other {Anfordern {2} Elemente}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>Beschreibung</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>Gebühren und Beschränkungen</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>Bitte beachten Sie:</0> Wenn Sie Ihre Liste per E-Mail an einen Archivar unter <1>archive@rockarch.org senden,</1> geben Sie bitte Ihren Namen und Ihre E-Mail-Adresse im Feld \"Nachricht\" an, da wir sonst keine Möglichkeit haben, Sie zu kontaktieren, um die Liste weiter zu bearbeiten."
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>Antrag einreichen</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>Online ansehen<1/></0><2>Herunterladen <3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>Wir berechnen in der Regel eine <1> Pauschalgebühr von 25 $ pro Stück</1>, wobei die Anzahl der <2>angeforderten Stücke auf 20 pro Kalenderjahr</2> begrenzt ist.</0><3>Weitere Einzelheiten, einschließlich Ausnahmen für audiovisuelles und übergroßes Material, finden Sie in den Informationen zu unseren <4>Vervielfältigungsdiensten</4>.</3><5>Wenn Sie Hilfe benötigen oder einen Scan in Publikationsqualität anfordern möchten, senden Sie eine E-Mail an einen Archivar unter <6>archive@rockarch.org.</6></5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "Maximal 255 Zeichen"
 
@@ -426,8 +426,8 @@ msgstr "Copyright © Rockefeller Archive Center. Alle Rechte vorbehalten."
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "kosten"
+#~ msgid "costs"
+#~ msgstr "kosten"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "Ich bin damit einverstanden, die Kosten für die Vervielfältigung. Siehe unsere <0>Gebührenordnung</0>."
 
@@ -650,8 +650,6 @@ msgstr "Ungültige E-Mail-Adresse angegeben."
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "einträge"
 
@@ -672,7 +670,7 @@ msgstr "Standort des Hauptsitzes"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "Nachricht"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "Nachricht an das RAC"
 
@@ -730,7 +728,7 @@ msgstr "Spitznamen"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "Es wurden keine Einträge zur Einreichung ausgewählt."
 
@@ -761,8 +759,8 @@ msgstr "öffnet E-Mail"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "Bitte geben Sie ein Wort oder einen Satz ein, nach dem Sie suchen möcht
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "Bitte füllen Sie dieses Feld aus."
 
@@ -844,8 +842,8 @@ msgstr "Datenschutzerklärung"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "fragen"
+#~ msgid "questions"
+#~ msgstr "fragen"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "Öffnungszeiten des Lesesaals:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "recaptcha"
 
@@ -1140,7 +1135,7 @@ msgstr "Virtuelle internationale Behördenakte"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "Wir können Ihren Antrag nur bearbeiten, wenn Sie sich bereit erklären, die Kosten für die Reproduktion zu übernehmen."
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {Introducing the Minimap}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>Description</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>Fees and limitations</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>Please note:</0> if are emailing your list to an archivist at <1>archive@rockarch.org</1>, please include your name and email address in the Message field, otherwise we will have no means of contacting you to follow-up."
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>Submit request</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>View Online<1/></0><2>Download <3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "255 characters maximum"
 
@@ -426,8 +426,8 @@ msgstr "Copyright © Rockefeller Archive Center. All rights reserved."
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "costs"
+#~ msgid "costs"
+#~ msgstr "costs"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 
@@ -650,8 +650,6 @@ msgstr "Invalid email address provided."
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "items"
 
@@ -672,7 +670,7 @@ msgstr "Location of Headquarters"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "Message"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "Message for RAC staff"
 
@@ -730,7 +728,7 @@ msgstr "Nicknames"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "No items have been selected to submit."
 
@@ -761,8 +759,8 @@ msgstr "opens email"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "Please add a word or phrase to search for."
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "Please complete this field."
 
@@ -844,8 +842,8 @@ msgstr "Privacy Policy"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "questions"
+#~ msgid "questions"
+#~ msgstr "questions"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "Reading Room Hours:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "recaptcha"
 
@@ -1140,7 +1135,7 @@ msgstr "Virtual International Authority File"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "We cannot process your request unless you agree to pay the costs of reproduction."
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {Introducción al minimapa}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {Solicitar {1} Items} other {Solicitar {2} Item}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>Descripción</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>Tarifas y limitaciones</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>Nota:</0> si envía su lista por correo electrónico a un archivero de <1>archive@rockarch.org,</1> incluya su nombre y dirección de correo electrónico en el campo Mensaje; de lo contrario, no podremos ponernos en contacto con usted para hacer un seguimiento."
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>Enviar solicitud</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>Ver en línea<1/></0><2>Descargar <3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>Por lo general, cobramos una <1> tarifa fija de 25 $ por artículo</1>, con un límite de <2>20 artículos solicitados por año natural</2>.</0><3>Para más información, incluidas las excepciones para materiales audiovisuales y de gran tamaño, consulte nuestros <4>servicios de duplicación</4>.</3><5>Para obtener ayuda o solicitar un escaneado con calidad de publicación, envíe un correo electrónico a un archivero a <6>archive@rockarch.org.</6></5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, Nueva York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "255 caracteres máximo"
 
@@ -426,8 +426,8 @@ msgstr "Copyright © Centro de Archivos Rockefeller. Todos los derechos reservad
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "promedias mensuales"
+#~ msgid "costs"
+#~ msgstr "promedias mensuales"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "Acepto pagar los gastos de las copias de esta solicitud. Consulte nuestra <0>lista de tarifas</0>."
 
@@ -650,8 +650,6 @@ msgstr "Dirección de correo electrónico no válida."
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "artículos"
 
@@ -672,7 +670,7 @@ msgstr "Ubicación de oficinas centrales"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "Mensaje"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "Mensaje para el personal del RAC"
 
@@ -730,7 +728,7 @@ msgstr "Apodos"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "No se ha seleccionado ningún artículo para presentar."
 
@@ -761,8 +759,8 @@ msgstr "abre el correo electrónico"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "Por favor, añada una palabra o frase a buscar."
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "Rellene este campo."
 
@@ -844,8 +842,8 @@ msgstr "Política de privacidad"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "preguntas"
+#~ msgid "questions"
+#~ msgstr "preguntas"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "Horario de la sala de lectura:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "recaptcha"
 
@@ -1140,7 +1135,7 @@ msgstr "Fichero virtual de autoridades internacionales"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "No podemos tramitar su solicitud a menos que acepte pagar los costes de reproducción."
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {Introduction de la carte minimale}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {Demander {1} éléments} other {Demander {2} élément}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>Description</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>Tarifs et limitations</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>Remarque :</0> si vous envoyez votre liste par courrier électronique à un archiviste à l'<1>adresse archive@rockarch.org,</1> veuillez indiquer votre nom et votre adresse électronique dans le champ Message, faute de quoi nous n'aurons aucun moyen de vous contacter pour assurer le suivi."
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>Soumettre une demande</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>Voir en ligne<1/></0><2>Télécharger <3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>Nous facturons généralement un montant <1> forfaitaire de 25 dollars par document</1>, dans la limite de <2>20 documents par année civile</2>.</0><3>Pour plus de détails, y compris les exceptions pour les documents audiovisuels et les documents surdimensionnés, consultez nos <4>services de duplication</4>.</3><5>Pour obtenir de l'aide ou demander une numérisation de qualité, envoyez un courriel à un archiviste à l'adresse <6>archive@rockarch.org.</6></5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "255 caractères maximum"
 
@@ -426,8 +426,8 @@ msgstr "Copyright © Rockefeller Archive Center. Tous droits réservés."
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "réduits"
+#~ msgid "costs"
+#~ msgstr "réduits"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "J’accepte de payer les frais de reproduction pour cette demande. Voir notre <0>tarifs</0>."
 
@@ -650,8 +650,6 @@ msgstr "L’adresse courriel fournie est invalide."
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "articles"
 
@@ -672,7 +670,7 @@ msgstr "Site du siège"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "Message"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "Message au personnel du RAC"
 
@@ -730,7 +728,7 @@ msgstr "Surnoms"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "Aucun élément n'a été sélectionné pour être soumis."
 
@@ -761,8 +759,8 @@ msgstr "ouvre le courrier électronique"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "Veuillez ajouter un mot ou une phrase à rechercher."
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "Veuillez remplir ce champ."
 
@@ -844,8 +842,8 @@ msgstr "Politique de confidentialité"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "questions"
+#~ msgid "questions"
+#~ msgstr "questions"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "Horaires de la salle de lecture:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "recaptcha"
 
@@ -1140,7 +1135,7 @@ msgstr "Fichier d'autorité internationale virtuelle"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "Nous ne pouvons pas traiter votre demande si vous n'acceptez pas de payer les frais de reproduction."
 

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {Introduzione della minimappa}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {Richiesta {1} Elementi} other {Richiesta {2} Elemento}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>Descrizione</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>Tariffe e limitazioni</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>Nota bene:</0> se state inviando la vostra lista via e-mail a un archivista di <1>archive@rockarch.org,</1> includete il vostro nome e l'indirizzo e-mail nel campo Messaggio, altrimenti non avremo modo di contattarvi per un follow-up."
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>Invia la richiesta</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>Visualizza online<1/></0><2>Scarica  <3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>In genere applichiamo una <1> tariffa forfettaria di 25 dollari per articolo</1>, con un limite di <2>20 articoli richiesti per anno solare</2>.</0><3>Per maggiori dettagli, comprese le eccezioni per i materiali audiovisivi e di grandi dimensioni, leggete i nostri <4>servizi di duplicazione</4>.</3><5>Per assistenza o per richiedere una scansione in qualità di pubblicazione, inviare un'e-mail a un archivista all'indirizzo <6>archive@rockarch.org.</6></5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "Massimo 255 caratteri"
 
@@ -426,8 +426,8 @@ msgstr "Copyright © Rockefeller Archive Center. Tutti i diritti riservati."
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "costi"
+#~ msgid "costs"
+#~ msgstr "costi"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "Accetto di sostenere  le spese  connesse a questa richiesta. Consulta il nostro <0>tariffario</0>."
 
@@ -650,8 +650,6 @@ msgstr "Indirizzo e-mail non valido."
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "oggetti"
 
@@ -672,7 +670,7 @@ msgstr "Ubicazione della sede centrale"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "Messaggio"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "Messaggio per il personale RAC"
 
@@ -730,7 +728,7 @@ msgstr "Soprannomi"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "Non sono stati selezionati articoli da inviare."
 
@@ -761,8 +759,8 @@ msgstr "apre l'e-mail"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "Aggiungete una parola o una frase da cercare."
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "Compilare questo campo."
 
@@ -844,8 +842,8 @@ msgstr "Informativa sulla privacy"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "domande"
+#~ msgid "questions"
+#~ msgstr "domande"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "Orari della sala di consultazione:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "recaptcha"
 
@@ -1140,7 +1135,7 @@ msgstr "Fascicolo dell'autorità internazionale virtuale"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "Non possiamo elaborare la vostra richiesta se non accettate di pagare i costi di riproduzione."
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {ミニマップの紹介}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {リクエスト {1} アイテム} other {リクエスト {2} アイテム}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>説明</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>料金と制限</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>注意：</0> <1>archive@rockarch.org</1> のアーキビストにリストをEメールで送る場合は、メッセージ欄にお名前とEメールアドレスをご記入ください。"
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>リクエストを送信</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>オンラインで見る<1/></0><2>ダウンロード<3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>通常、<1>1点につき一律25ドル</1>で、<2>年間20点まで</2>承ります。</0><3>視聴覚資料や特大資料の例外を含む詳細については、<4>複写</4>サービスについてをお読みください。</3><5>出版物品質のスキャンをご希望の方は、<6>archive@rockarch.org</6>。</5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "最大255文字"
 
@@ -426,8 +426,8 @@ msgstr "著作権 © ロックフェラー・アーカイブ・センター.無�
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "費用"
+#~ msgid "costs"
+#~ msgstr "費用"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "私は、この依頼にかかる複製費用を支払うことに同意します。<0>料金表を</0>ご覧ください。"
 
@@ -650,8 +650,6 @@ msgstr "無効な電子メール アドレスが指定されました。"
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "アイテム"
 
@@ -672,7 +670,7 @@ msgstr "所在地"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "メッセージ"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "RACスタッフへのメッセージ"
 
@@ -730,7 +728,7 @@ msgstr "ニックネーム"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "提出するアイテムが選択されていない。"
 
@@ -761,8 +759,8 @@ msgstr "メールを開く"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "検索する語句を追加してください。"
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "この欄にご記入ください。"
 
@@ -844,8 +842,8 @@ msgstr "プライバシーポリシー"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "質問"
+#~ msgid "questions"
+#~ msgstr "質問"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "閲覧室の開室時間:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "リキャプチャ"
 
@@ -1140,7 +1135,7 @@ msgstr "仮想国際機関ファイル"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "お客様が複製費用の支払いに同意されない限り、当社はお客様のご依頼を処理することはできません。"
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {미니맵 소개}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {요청 {1} 항목} other {요청 {2} 항목}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>설명</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>수수료 및 제한 사항</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>참고:</0> 목록을 아카이브 담당자에게 이메일( <1>archive@rockarch.org</1>)로 보내는 경우 메시지 필드에 이름과 이메일 주소를 기재해 주세요. 그렇지 않으면 후속 조치를 위해 연락할 방법이 없습니다."
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>요청 제출</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>온라인 보기<1/></0><2>다운로드 <3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>일반적으로 <1> 항목당 $25의 정액 수수료가</1> 부과되며, <2>연간 요청 건수는 20건으로</2> 제한됩니다.</0><3>시청각 자료 및 대형 자료에 대한 예외를 포함한 자세한 내용은 <4>복제 서비스에</4> 대한 도움말을 참조하세요.</3><5>도움이 필요하거나 출판물 품질 스캔을 요청하려면 아카이브 담당자에게 이메일( <6>archive@rockarch.org</6>)로 문의하세요.</5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>슬리피 할로우, 뉴욕 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "최대 255자"
 
@@ -426,8 +426,8 @@ msgstr "저작권 © 록펠러 아카이브 센터. 모든 권리 보유."
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "비용"
+#~ msgid "costs"
+#~ msgstr "비용"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "이 자료를 복사하는 비용을 지불하는 것에 동의합니다. <0>수수료 일정을</0> 참조하세요."
 
@@ -650,8 +650,6 @@ msgstr "입력한 이메일 주소가 잘못되었습니다."
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "아이템"
 
@@ -672,7 +670,7 @@ msgstr "본사 위치"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "본문"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "RAC 직원을 위한 메시지"
 
@@ -730,7 +728,7 @@ msgstr "닉네임"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "제출할 항목이 선택되지 않았습니다."
 
@@ -761,8 +759,8 @@ msgstr "이메일 열기"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "검색할 단어나 구문을 추가하세요."
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "이 필드를 작성해 주세요."
 
@@ -844,8 +842,8 @@ msgstr "개인정보 보호 정책"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "고객문의"
+#~ msgid "questions"
+#~ msgstr "고객문의"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "열람실 이용 시간:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "보안 문자"
 
@@ -1140,7 +1135,7 @@ msgstr "가상 국제 기관 파일"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "귀하가 복제 비용 지불에 동의하지 않으면 요청을 처리할 수 없습니다."
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {Apresentando o Minimapa}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {Solicitar {1} Item} other {Solicitar Unid {2}}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>Descrição</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>Tarifas e limitações</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>Observação:</0> se estiver enviando sua lista por e-mail para um arquivista em <1>archive@rockarch.org,</1> inclua seu nome e endereço de e-mail no campo Mensagem, caso contrário não teremos como contatá-lo para dar continuidade."
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>Enviar solicitação</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>Exibir online<1/></0><2>Baixar <3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>Em geral, cobramos uma <1> tarifa fixa de US$ 25 por item</1>, com um limite de <2>20 itens solicitados por ano civil</2>.</0><3>Para obter mais detalhes, inclusive exceções para materiais audiovisuais e de grandes dimensões, leia sobre nossos <4>serviços de duplicação</4>.</3><5>Para obter ajuda ou solicitar uma digitalização com qualidade de publicação, envie um e-mail para um arquivista em <6>archive@rockarch.org.</6></5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, Nova York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "máximo de 255 caracteres"
 
@@ -426,8 +426,8 @@ msgstr "Direitos autorais © Rockefeller Archive Center. Todos os direitos reser
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "custos"
+#~ msgid "costs"
+#~ msgstr "custos"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "oncordo em pagar os custos de cópia desta solicitação. Por favor, consulte nossa <0>lista de tarifas</0>."
 
@@ -650,8 +650,6 @@ msgstr "Endereço de e-mail inválido fornecido."
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "itens"
 
@@ -672,7 +670,7 @@ msgstr "Localização da sede"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "Mensagem"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "Mensagem aos funcionários do RAC"
 
@@ -730,7 +728,7 @@ msgstr "Apelidos"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "Nenhum item foi selecionado para envio."
 
@@ -761,8 +759,8 @@ msgstr "abre o e-mail"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "Adicione uma palavra ou frase para pesquisar."
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "Preencha este campo."
 
@@ -844,8 +842,8 @@ msgstr "Política de Privacidade"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "questões"
+#~ msgid "questions"
+#~ msgstr "questões"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "Horário da sala de leitura:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "recaptcha"
 
@@ -1140,7 +1135,7 @@ msgstr "Arquivo virtual de autoridade internacional"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "Não poderemos processar sua solicitação a menos que você concorde em pagar os custos de reprodução."
 

--- a/src/locales/tr/messages.po
+++ b/src/locales/tr/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {Minimap Tanıtımı}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {Materyalleri̇ Talep et {1}} other {Materyalleri̇ Talep et {2}}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>Açıklama</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>Ücretlendirme ve sınırlamalar</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>Lütfen dikkat:</0> listenizi <1>archive@rockarch.org</1> adresindeki bir arşivciye e-posta ile gönderiyorsanız, lütfen Mesaj alanına adınızı ve e-posta adresinizi ekleyin, aksi takdirde takip etmek için sizinle iletişime geçme imkanımız olmayacaktır."
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>İstek gönder</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>Çevrimiçi Görüntüle<1/></0><2>İndi̇r <3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0><2>Takvim yılı başına talep edilen materyal sayısı 20</2> ile sınırlı olmak üzere, genellikle materyal <1> başına 25 ABD doları sabit ücret</1> alıyoruz.</0><3>Görsel-işitsel ve büyük boyutlu materyaller için istisnalar da dahil olmak üzere daha fazla ayrıntı için <4>çoğaltma hizmetlerimiz</4> hakkında bilgi edinin.</3><5>Yardım almak veya yayın kalitesinde tarama talep etmek için <6>archive@rockarch.org</6> adresinden bir arşiv uzmanına e-posta gönderin.</5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "En fazla 255 karakter"
 
@@ -426,8 +426,8 @@ msgstr "Telif Hakkı © Rockefeller Arşiv Merkezi. Tüm hakları saklıdır."
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "maliyetler"
+#~ msgid "costs"
+#~ msgstr "maliyetler"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "Bu talep için çoğaltma masraflarını ödemeyi kabul ediyorum. <0>Ücretlendirme</0> planına bakınız."
 
@@ -650,8 +650,6 @@ msgstr "Geçersiz e-posta adresi verildi."
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "öğeler"
 
@@ -672,7 +670,7 @@ msgstr "Genel Merkezi̇n Bulunduğu Yer"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "Mesaj"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "RAC personeline mesaj"
 
@@ -730,7 +728,7 @@ msgstr "Takma Adlar"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "Gönderilmek üzere hiçbir öğe seçilmemiştir."
 
@@ -761,8 +759,8 @@ msgstr "e-posta açar"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "Lütfen aramak için bir kelime veya cümle ekleyin."
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "Lütfen bu alanı doldurunuz."
 
@@ -844,8 +842,8 @@ msgstr "Kişisel Verilere Dair Politika"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "Sorular"
+#~ msgid "questions"
+#~ msgstr "Sorular"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "Okuma Odası Saatleri:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "recaptcha"
 
@@ -1140,7 +1135,7 @@ msgstr "Sanal Uluslararası Yetki Dosyası"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "Çoğaltma masraflarını ödemeyi kabul etmediğiniz sürece talebinizi işleme koyamayız."
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -43,8 +43,8 @@ msgid "{0, select, true {Minimap} other {Introducing the Minimap}}"
 msgstr "{0, select, true {Minimap} other {引入最小图}}"
 
 #. Text for submiting item(s) request
-#: src/components/ModalMyList/index.js:475
-#: src/components/ModalMyList/index.js:625
+#: src/components/ModalMyList/index.js:466
+#: src/components/ModalMyList/index.js:609
 msgid "{0, select, true {Request {1} Items} other {Request {2} Item}}"
 msgstr "{0, select, true {请求 {1} 项目} other {请求 {2} 项目}}"
 
@@ -179,7 +179,7 @@ msgid "<0>Description</0>"
 msgstr "<0>背景说明</0>"
 
 #. Fees and limitations title
-#: src/components/ModalMyList/index.js:518
+#: src/components/ModalMyList/index.js:509
 msgid "<0>Fees and limitations</0>"
 msgstr "<0>费用和限制</0>"
 
@@ -239,7 +239,7 @@ msgid "<0>Please note:</0> if are emailing your list to an archivist at <1>archi
 msgstr "<0>请注意：</0>如果要将您的名单通过电子邮件发送给<1>archive@rockarch.org</1> 的档案管理员<1>，</1>请在 \"信息 \"栏中注明您的姓名和电子邮件地址，否则我们将无法与您联系，无法跟进。"
 
 #. Submit Request title
-#: src/components/ModalMyList/index.js:546
+#: src/components/ModalMyList/index.js:537
 msgid "<0>Submit request</0>"
 msgstr "<0>提交申请</0>"
 
@@ -269,7 +269,7 @@ msgid "<0>View Online<1/></0><2>Download <3/></2>{0}"
 msgstr "<0>在线阅读<1/></0><2>下载<3/></2>{0}"
 
 #. Fees and limitations information
-#: src/components/ModalMyList/index.js:521
+#: src/components/ModalMyList/index.js:512
 msgid "<0>We generally charge a <1>$25 flat fee per item</1>, with a limit of <2>20 items requested per calendar year</2>.</0><3>For more details, including exceptions for audiovisual and oversized materials, read about our <4>duplication services</4>.</3><5>For help or to request a publication quality scan, email an archivist at <6>archive@rockarch.org</6>.</5>"
 msgstr "<0>一般情况下，我们对<1>每件物品</1>收取<1> 25 美元的统一费用</1>，每个<2>日历年仅限申请 20 件物品</2>。</0><3>更多详情，包括视听材料和超大材料的例外情况，请阅读我们的<4>复制服务</4>。</3><5>如需帮助或索取出版物质量的扫描件，请发送电子邮件至<6>archive@rockarch.org</6> 联系档案管理员。</5>"
 
@@ -279,7 +279,7 @@ msgid "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 msgstr "15 Dayton Avenue<0/>Sleepy Hollow, New York 10591"
 
 #. helptext for RAC staff message
-#: src/components/ModalMyList/index.js:448
+#: src/components/ModalMyList/index.js:446
 msgid "255 characters maximum"
 msgstr "最多 255 个字符"
 
@@ -426,8 +426,8 @@ msgstr "洛克菲勒档案中心版权所有。保留所有权利。"
 
 #. Name for duplication request form costs
 #: src/components/ModalMyList/index.js:601
-msgid "costs"
-msgstr "费用"
+#~ msgid "costs"
+#~ msgstr "费用"
 
 #. Title for Creator filter
 #: src/components/ModalSearch/index.js:93
@@ -602,8 +602,8 @@ msgstr "https://rockarch.org/collections/access-and-request-materials/"
 
 #. Link for duplication request services
 #. Link for duplication request services
-#: src/components/ModalMyList/index.js:533
-#: src/components/ModalMyList/index.js:595
+#: src/components/ModalMyList/index.js:524
+#: src/components/ModalMyList/index.js:584
 msgid "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 msgstr "https://rockarch.org/collections/access-and-request-materials/#duplication-services"
 
@@ -638,7 +638,7 @@ msgid "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 msgstr "https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg"
 
 #. Label for duplication request form
-#: src/components/ModalMyList/index.js:587
+#: src/components/ModalMyList/index.js:576
 msgid "I agree to pay the duplication costs for this request. See our <0>fee schedule</0>."
 msgstr "我同意支付此申请的复制费用。请参阅我们的<0>收费表</0>。"
 
@@ -650,8 +650,6 @@ msgstr "提供的电子邮件地址无效。"
 #. Name of items error message
 #: src/components/ModalMyList/index.js:31
 #: src/components/ModalMyList/index.js:217
-#: src/components/ModalMyList/index.js:435
-#: src/components/ModalMyList/index.js:581
 msgid "items"
 msgstr "项目"
 
@@ -672,7 +670,7 @@ msgstr "总部所在地"
 
 #. Company Email link
 #: src/components/ModalMyList/index.js:174
-#: src/components/ModalMyList/index.js:542
+#: src/components/ModalMyList/index.js:533
 #: src/components/PageBackendError/index.js:19
 #: src/components/PrimaryLink/index.js:33
 msgid "mailto:archive@rockarch.org"
@@ -697,7 +695,7 @@ msgstr "信息"
 
 #. Label for RAC staff message Form
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:189
-#: src/components/ModalMyList/index.js:444
+#: src/components/ModalMyList/index.js:442
 msgid "Message for RAC staff"
 msgstr "给洛克菲勒档案中心的档案管理员留言"
 
@@ -730,7 +728,7 @@ msgstr "昵称"
 #. No selected items error
 #: src/components/ModalMyList/index.js:198
 #: src/components/ModalMyList/index.js:415
-#: src/components/ModalMyList/index.js:563
+#: src/components/ModalMyList/index.js:554
 msgid "No items have been selected to submit."
 msgstr "没有选择要提交的项目。"
 
@@ -761,8 +759,8 @@ msgstr "打开电子邮件"
 #. Title for duplication request
 #. Title for new window button
 #. Title message for opening an online item
-#: src/components/ModalMyList/index.js:529
-#: src/components/ModalMyList/index.js:591
+#: src/components/ModalMyList/index.js:520
+#: src/components/ModalMyList/index.js:580
 #: src/components/PageDigitalObject/index.js:112
 #: src/components/RecordsDetail/index.js:229
 msgid "opens in a new window"
@@ -800,7 +798,7 @@ msgstr "请添加要搜索的单词或短语。"
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:277
 #: src/components/ModalMyList/index.js:194
 #: src/components/ModalMyList/index.js:412
-#: src/components/ModalMyList/index.js:556
+#: src/components/ModalMyList/index.js:547
 msgid "Please complete this field."
 msgstr "请填写此栏。"
 
@@ -844,8 +842,8 @@ msgstr "隐私政策"
 
 #. Name for RAC staff message Form
 #: src/components/ModalMyList/index.js:452
-msgid "questions"
-msgstr "问题"
+#~ msgid "questions"
+#~ msgstr "问题"
 
 #. Footer.Primary.RAC.message
 #: src/components/PrimaryLink/index.js:89
@@ -861,10 +859,7 @@ msgstr "阅览室开放时间:"
 #. Name of recaptcha error message
 #: src/components/ModalMyList/index.js:260
 #: src/components/ModalMyList/index.js:267
-#: src/components/ModalMyList/index.js:462
-#: src/components/ModalMyList/index.js:468
-#: src/components/ModalMyList/index.js:612
-#: src/components/ModalMyList/index.js:618
+#: src/components/ModalMyList/index.js:598
 msgid "recaptcha"
 msgstr "重新验证"
 
@@ -1140,7 +1135,7 @@ msgstr "虚拟国际权威档案"
 #. Payment Modal Form Test
 #. Costs not agreed to error
 #: src/components/ModalMyList/__tests__/ModalMyList.test.js:280
-#: src/components/ModalMyList/index.js:559
+#: src/components/ModalMyList/index.js:550
 msgid "We cannot process your request unless you agree to pay the costs of reproduction."
 msgstr "除非您同意支付复制费用，否则我们无法处理您的申请。"
 


### PR DESCRIPTION
Removes translation of name attributes in forms, in particular the `costs` field in the duplication modal.