### PR TITLE
Update custom pageview event for analytics

### DIFF
--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -81,23 +81,3 @@ export const truncateString = (text, maxLength) => {
     return null
   }
 }
-
-/** Sends a custom pageview event to Matomo Tag Manager.
-* This allows us to ensure that the correct page titles are sent.  */
-var done = false
-var prevTitle = ''
-export const firePageViewEvent = title => {
-  if (title && title !== prevTitle) {
-    done = false
-  }
-  if (title && !done) {
-    if (window && window._mtm) {
-      let dataLayer = window._mtm || [];
-      dataLayer.push({
-        'event': 'reactPageViewEvent'
-      });
-      done = true
-      prevTitle = title
-    }
-  }
-}

--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -81,3 +81,22 @@ export const truncateString = (text, maxLength) => {
     return null
   }
 }
+
+/** Sends a custom pageview event to Matomo Tag Manager
+* with pageTitle and pageUrl variables  */
+let lastFiredUrl = null;
+
+export const firePageViewEvent = () => {
+  const currentUrl = window.location.href;
+  // Handle translation, data loading, etc. - if already fired for this URL, skip
+  if (currentUrl === lastFiredUrl) {
+    return;
+  }
+  lastFiredUrl = currentUrl;
+  if (window && window._mtm) {
+    let dataLayer = window._mtm || [];
+    dataLayer.push({
+      event: 'reactPageViewEvent',
+    });
+  }
+}

--- a/src/components/Helpers.js
+++ b/src/components/Helpers.js
@@ -82,8 +82,7 @@ export const truncateString = (text, maxLength) => {
   }
 }
 
-/** Sends a custom pageview event to Matomo Tag Manager
-* with pageTitle and pageUrl variables  */
+/** Sends a custom pageview event to Matomo Tag Manager*/
 let lastFiredUrl = null;
 
 export const firePageViewEvent = () => {


### PR DESCRIPTION
Address issue #804 

Update: I believe translation is a complicating factor here, so it turns out application code is still required to track pageviews correctly. This PR instead updates the existing code to track URL changes instead of page title changes.

Original PR:
Analytics pageview and page title tracking are now handled in Matomo Tag Manager, with no application code required.

Tested the new configuration in Matomo and it is working as expected, so this PR is just about making sure we remove the obsolete code.
