### PR TITLE
fix: Update fetch from Wikidata to accommodate changes to response structure

### DIFF
--- a/src/components/PageAgent/index.js
+++ b/src/components/PageAgent/index.js
@@ -157,7 +157,8 @@ const PageAgent = () => {
   useEffect(() => {
     let noteText = agent.notes && agent.notes.map(note => note.subnotes.map(s => s.content).join('\r\n'))
     if (!noteText && wikidata.sitelinks && wikidata.sitelinks.enwiki) { /* 1 */
-      const wikidataTitle = wikidata.sitelinks.enwiki.url.split('/').at(-1)
+      console.log(wikidata)
+      const wikidataTitle = wikidata.sitelinks.enwiki.title
       axios
         .get(`https://en.wikipedia.org/api/rest_v1/page/summary/${wikidataTitle}`)
         .then(res => {


### PR DESCRIPTION
Use the `name` property directly instead of parsing URL.